### PR TITLE
WIP: Add initial code, tests, and update docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ puf.csv
 *.ipynb
 __pycache__/
 .pytest_cache/
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -11,6 +11,20 @@ of accuracy and the code should not yet be used for publications or research
 purposes. Until there is an initial stable release, continuous refactoring
 should be expected.
 
+## Installing Tax-Brain
+
+Currently you can only install Tax-Brain from source:
+
+```
+git clone https://github.com/PSLmodels/Tax-Brain
+cd Tax-Brain
+pip install -e .
+```
+
+## Using Tax-Brain
+
+View the sample code in [example.py](example.py) to see how to run Tax-Brain
+
 ## Additional Information
 
 * [Project Road Map](ROADMAP.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,9 +7,13 @@ and [Behavioral-Responses](https://www.pslmodels.org/Catalog/Behavioral-Response
 packages. We also want to provide an interface for COMP that will mimic the
 current capabilities of [TaxBrain](https://www.ospc.org/taxbrain/).
 
+Along those lines, TaxBrain will need to be updated to allow users to take full
+advantage of the `GrowDiff` capabilities of Tax-Calculator.
+
 ## Long-Term
 
 The next models to be incorporated into Tax-Brain will be (in no particular order):
+
 * [B-Tax](https://www.pslmodels.org/Catalog/B-Tax.html)
 * [OG-USA](https://www.pslmodels.org/Catalog/OG-USA.html)
 * [Business-Taxation](https://github.com/PSLmodels/Business-Taxation)

--- a/example.py
+++ b/example.py
@@ -1,0 +1,16 @@
+from taxbrain import TaxBrain
+
+reform_url = "https://raw.githubusercontent.com/PSLmodels/Tax-Calculator/b6c09ecc8c59850647f00e42097b57d594e1ce94/taxcalc/reforms/2017_law.json"
+tb = TaxBrain(2018, 2027, use_cps=True, reform=reform_url)
+# run static analysis
+tb.static_run()
+static_table = tb.weighted_totals('c00100', 'static')
+print('Tax Liability by Year')
+print('Static Results')
+print(static_table)
+
+# run dynamic analysis
+tb.dynamic_run({2018: {"BE_sub": 0.25}})
+dynamic_table = tb.weighted_totals('c00100', 'dynamic')
+print('Dynamic Results')
+print(dynamic_table)

--- a/taxbrain/__init__.py
+++ b/taxbrain/__init__.py
@@ -1,0 +1,1 @@
+from taxbrain.taxbrain import *

--- a/taxbrain/taxbrain.py
+++ b/taxbrain/taxbrain.py
@@ -1,0 +1,143 @@
+import copy
+import taxcalc as tc
+import pandas as pd
+from taxcalc.utils import DIST_VARIABLES
+from behresp import response
+from dask import compute, delayed
+
+
+class TaxBrain:
+
+    FIRST_BUDGET_YEAR = tc.Policy.JSON_START_YEAR
+    LAST_BUDGET_YEAR = tc.Policy.LAST_BUDGET_YEAR
+
+    def __init__(self, start_year, end_year, microdata='puf.csv',
+                 use_cps=False, reform=None, assump=None, verbose=False):
+        """
+        Constructor for the TaxBrain class
+        Parameters
+        ----------
+        microdata: Either a Pandas DataFrame or path to the PUF
+        policy: individual income tax policy. Can be either a string
+        behavior: behavioral assumptions
+        verbose: specifies whether or not to write progress in stdout
+        """
+        if use_cps and microdata != "puf.csv":
+            raise ValueError("Specified a data file with both microdata and "
+                             "use_cps=True; you can only specify one.")
+        assert isinstance(start_year, int) & isinstance(end_year, int), (
+            "Start and end years must be integers"
+        )
+        assert start_year <= end_year, (f"Specified end year, {end_year}, is "
+                                        "before specified start year,"
+                                        f"{start_year}.")
+        assert TaxBrain.FIRST_BUDGET_YEAR <= start_year, (
+            f"Specified start_year, {start_year}, comes before first known "
+            f"budget year, {TaxBrain.FIRST_BUDGET_YEAR}."
+        )
+        assert end_year <= TaxBrain.LAST_BUDGET_YEAR, (
+            f"Specified end_year, {end_year}, comes after last known "
+            f"budget year, {TaxBrain.LAST_BUDGET_YEAR}."
+        )
+        self.start_year = start_year
+        self.end_year = end_year
+        self.base_data = {yr: {} for yr in range(start_year, end_year + 1)}
+        self.reform_data = {yr: {} for yr in range(start_year, end_year + 1)}
+        self.verbose = verbose
+
+        # Create two microsimulation calculators
+        # Baseline calculator
+        if use_cps:
+            records = tc.Records.cps_constructor()
+        else:
+            records = tc.Records(microdata)
+        self.base_calc = tc.Calculator(policy=tc.Policy(), records=records,
+                                       verbose=self.verbose)
+
+        # Reform calculator
+        # Initialize a policy object
+        self.params = tc.Calculator.read_json_param_objects(reform, assump)
+        policy = tc.Policy()
+        policy.implement_reform(self.params['policy'])
+        # Initialize Calculator
+        self.reform_calc = tc.Calculator(policy=policy, records=records,
+                                         verbose=self.verbose)
+
+    def static_run(self, varlist=DIST_VARIABLES):
+        """
+        Run the calculator
+        """
+        if "s006" not in varlist:  # ensure weight is always included
+            varlist.append("s006")
+        if self.verbose:
+            print("Running static simulations")
+        # Use copies of the calculators so you can run both static and
+        # dynamic calculations on same TaxBrain instance
+        base_calc = copy.deepcopy(self.base_calc)
+        reform_calc = copy.deepcopy(self.reform_calc)
+        for yr in range(self.start_year, self.end_year + 1):
+            base_calc.advance_to_year(yr)
+            reform_calc.advance_to_year(yr)
+            # run calculations in parallel
+            delay = [delayed(base_calc.calc_all()),
+                     delayed(reform_calc.calc_all())]
+            _ = compute(*delay)
+            self.base_data[yr]["static"] = base_calc.dataframe(varlist)
+            self.reform_data[yr]["static"] = reform_calc.dataframe(varlist)
+
+        del base_calc, reform_calc
+
+    def dynamic_run(self, behavior):
+        """
+        Run a dynamic response
+        """
+        if self.verbose:
+            print("Running dynamic simulations")
+
+        delay_list = []
+        for year in range(self.start_year, self.end_year + 1):
+            delay = delayed(self._run_dynamic_calc)(self.base_calc,
+                                                    self.reform_calc,
+                                                    behavior,
+                                                    year)
+            delay_list.append(delay)
+        _ = compute(*delay_list)
+        del delay_list
+
+    def weighted_totals(self, var, run_type):
+        assert run_type == "static" or run_type == "dynamic", (
+            "run_type must be either 'static' or 'dynamic'"
+        )
+        base_totals = {}
+        reform_totals = {}
+        differences = {}
+        for year in range(self.start_year, self.end_year + 1):
+            base_totals[year] = (self.base_data[year][run_type]["s006"] *
+                                 self.base_data[year][run_type][var]).sum()
+            reform_totals[year] = (self.reform_data[year][run_type]["s006"] *
+                                   self.reform_data[year][run_type][var]).sum()
+            differences[year] = reform_totals[year] - base_totals[year]
+        return pd.DataFrame([base_totals, reform_totals, differences],
+                            index=["Base", "Reform", "Difference"])
+
+    # ----- private methods -----
+    def _run_dynamic_calc(self, calc1, calc2, behavior, year):
+        """
+        Function used to parallelize the dynamic run function
+
+        Parameters
+        ----------
+        calc1: Calculator object representing the baseline policy
+        calc2: Calculator object representing the reform policy
+        year: year for the calculations
+        """
+        calc1_copy = copy.deepcopy(calc1)
+        calc2_copy = copy.deepcopy(calc2)
+        calc1_copy.advance_to_year(year)
+        calc2_copy.advance_to_year(year)
+        # use response function to capture dynamic effects
+        base, reform = response(calc1_copy, calc2_copy,
+                                behavior, self.verbose)
+        self.base_data[year]["dynamic"] = base
+        self.reform_data[year]["dynamic"] = reform
+        del calc1_copy, calc2_copy

--- a/taxbrain/tests/conftest.py
+++ b/taxbrain/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+from taxbrain import TaxBrain
+
+
+@pytest.fixture(scope="session")
+def tb():
+    return TaxBrain(2018, 2019, use_cps=True)

--- a/taxbrain/tests/test_brain.py
+++ b/taxbrain/tests/test_brain.py
@@ -1,0 +1,33 @@
+import pytest
+import pandas as pd
+from taxbrain import TaxBrain
+
+
+def test_arg_validation():
+    with pytest.raises(ValueError):
+        TaxBrain(2018, 2020, microdata='../puf.csv', use_cps=True)
+    with pytest.raises(AssertionError):
+        TaxBrain('2018', '2020')
+    with pytest.raises(AssertionError):
+        TaxBrain(2020, 2018)
+    with pytest.raises(AssertionError):
+        TaxBrain(2010, 2018)
+    with pytest.raises(AssertionError):
+        TaxBrain(2018, 2030)
+
+
+def test_static_run(tb):
+    tb.static_run()
+
+
+def test_dynamic_run(tb):
+    tb.dynamic_run()
+
+
+def test_weighted_totals(tb):
+    table = tb.weighted_totals('c00100', 'static')
+    assert isinstance(table, pd.DataFrame)
+    table = tb.weighted_totals('c00100', 'dynamic')
+    assert isinstance(table, pd.DataFrame)
+    with pytest.raises(AssertionError):
+        tb.weighted_totals('c00100', 'total')


### PR DESCRIPTION
This PR adds some initial Tax-Brain logic. Here's a walk through of how it all works:

You start by creating a `TaxBrain` object using `from taxbrain import TaxBrain`. The `TaxBrain` class takes seven arguments:

1. `start_year`: the first year in the analysis. Must be no earlier than 2013
2. `end_year`: the last year in the analysis. Must be no later than the last year Tax-Calc has weights for
3. `microdata`: either a path to a micro-data file, such as `puf.csv` or a DataFrame containing that data. Default value is `puf.csv`
4. `use_cps`: boolean indicator for whether or not to use the CPS in the analysis. Default is False.
5. `reform`: a string with either a URL pointing to a JSON reform file online, a path to a reform JSON file, or the JSON file's contents. (I'll generalize this to allow dictionary inputs in a future commit). Default is `None`
6. `assump`: same as `reform`, but the JSON file contains economic assumptions
7. `verbose` boolean indicator to determine if the user wants the model to print output as it runs. Default is `False`

Once a TaxBrain object is initiated, it creates two calculator objects: `base_calc` and `reform_calc`. I make two calculators because I'm making the assumption users of Tax-Brain will be using it because they have a reform to score. Thus, they would be making at least two calculators any way and automatically making two will save time down the road. This decision will also make more sense as I explain the other methods.

The first method of the `TaxBrain` class is `static_run`. This method runs both the base and reform calculators from the start to end year. Along the way it stores DataFrames containing variables extracted from each calculators in two separate dictionaries: `reform_data` and `base_data`. The user specifies which variables they want to extract using the `varlist` argument.

The second is `dynamic_run`. It does basically the same thing as `static_run`, but by calling `response` from the Behavioral-Response package to account for dynamic effects. You also cannot specify which variables are stored, instead the DataFrame returned by `response` is stored in the dictionaries.

The third and final method I've included so far is `weighted_totals`. This method is used to create a DataFrame with the weighted total for a given variable in the base and reform calculators as well as the difference between the two like the one below. You can also specify if you want the table to be from the static or dynamic run.

| | 2018       |         2019         |         2020         |         2021         |         2022         |         2023         |         2024         |         2025         | 2026           |         2027  |                        | 
|---|------------|----------------------|----------------------|----------------------|----------------------|----------------------|----------------------|----------------------|----------------|---------------|------------------------| 
| Base       |   1.100001e+13       | 1.147437e+13         | 1.194647e+13         | 1.245558e+13         | 1.299595e+13         | 1.355562e+13         | 1.412713e+13         | 1.469399e+13   | 1.528502e+13  | $15,916,310,000,000.00 | 
| Reform     |   1.085953e+13       | 1.133314e+13         | 1.179798e+13         | 1.230106e+13         | 1.283744e+13         | 1.339053e+13         | 1.395533e+13         | 1.451389e+13   | 1.529484e+13  | $15,927,520,000,000.00 | 
| Difference | -$140,485,800,000.00 | -$141,224,000,000.00 | -$148,488,000,000.00 | -$154,526,200,000.00 | -$158,502,300,000.00 | -$165,087,800,000.00 | -$171,798,700,000.00 | -1.801041e+11  | 9.820031e+09  | $11,206,970,000.00     | 

There's one private method: `_run_dynamic_calc` that is used to parallelize running the dynamic reforms.

An example for how to run it can be seen in `example.py`. 

I have no doubt that Tax-Brain's capabilities and uses will change significantly in the coming weeks and months, but I figure this is a step towards giving it the capacities currently found on `ospc.org/taxbrain`.

cc @MattHJensen @hdoupe 
