### PR TITLE
Add more sophisticated user input processing

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,8 +10,6 @@ current capabilities of [TaxBrain](https://www.ospc.org/taxbrain/).
 Along those lines, TaxBrain will need to be updated to allow users to take full
 advantage of the `GrowDiff` capabilities of Tax-Calculator.
 
-* Generalize Tax-Brian initialization so that a user can pass a reform as a dictionary or JSON
-
 ## Long-Term
 
 The next models to be incorporated into Tax-Brain will be (in no particular order):

--- a/taxbrain/tests/conftest.py
+++ b/taxbrain/tests/conftest.py
@@ -25,6 +25,18 @@ def reform_json_str():
     return reform
 
 
+@pytest.fixture(scope="session")
+def assump_json_str():
+    assump = """
+        {
+            "consumption": {"_BEN_housing_value": {"2019": [0.7]}},
+            "growdiff_baseline": {"_ABOOK": {"2019": [0.01]}},
+            "growdiff_response": {"_ACGNC": {"2019": [0.01]}}
+        }
+    """
+    return assump
+
+
 @pytest.fixture(scope="session",)
 def tb_static(reform_json_str):
     return TaxBrain(2018, 2019, use_cps=True, reform=reform_json_str)

--- a/taxbrain/tests/conftest.py
+++ b/taxbrain/tests/conftest.py
@@ -3,7 +3,7 @@ from taxbrain import TaxBrain
 
 
 @pytest.fixture(scope="session")
-def reform():
+def reform_json_str():
     reform = """
         {
             "policy": {
@@ -26,13 +26,13 @@ def reform():
 
 
 @pytest.fixture(scope="session",)
-def tb_static(reform):
-    return TaxBrain(2018, 2019, use_cps=True, reform=reform)
+def tb_static(reform_json_str):
+    return TaxBrain(2018, 2019, use_cps=True, reform=reform_json_str)
 
 
 @pytest.fixture(scope="session")
-def tb_dynamic(reform):
-    return TaxBrain(2018, 2019, use_cps=True, reform=reform,
+def tb_dynamic(reform_json_str):
+    return TaxBrain(2018, 2019, use_cps=True, reform=reform_json_str,
                     behavior={2018: {"BE_sub": 0.25}})
 
 

--- a/taxbrain/tests/test_brain.py
+++ b/taxbrain/tests/test_brain.py
@@ -9,11 +9,11 @@ def test_arg_validation():
     with pytest.raises(AssertionError):
         TaxBrain("2018", "2020")
     with pytest.raises(AssertionError):
-        TaxBrain(2020, 2018)
+        TaxBrain(TaxBrain.LAST_BUDGET_YEAR, TaxBrain.FIRST_BUDGET_YEAR)
     with pytest.raises(AssertionError):
-        TaxBrain(2010, 2018)
+        TaxBrain(TaxBrain.FIRST_BUDGET_YEAR - 1, 2018)
     with pytest.raises(AssertionError):
-        TaxBrain(2018, 2030)
+        TaxBrain(2018, TaxBrain.LAST_BUDGET_YEAR + 1)
 
 
 def test_static_run(tb_static):
@@ -44,3 +44,43 @@ def test_distribution_table(tb_static):
     with pytest.raises(ValueError):
         tb_static.distribution_table(2018, "weighted_deciles",
                                      "expanded_income", "nonreform")
+
+
+def test_user_input(reform_json_str):
+    valid_reform = {
+        2019: {
+            "_II_rt7": [0.40]
+        }
+    }
+    # Test valid reform dictionary with No assumption
+    TaxBrain(2018, 2020, use_cps=True, reform=valid_reform)
+    TaxBrain(2018, 2020, use_cps=True, reform=reform_json_str)
+    invalid_assump = {
+        "consumption": {}
+    }
+    # Test valid reform and assumptions dictionary
+    valid_assump = {
+        "consumption": {},
+        "growdiff_baseline": {},
+        "growdiff_response": {}
+    }
+    TaxBrain(2018, 2019, use_cps=True, assump=valid_assump)
+    tb = TaxBrain(2018, 2019, use_cps=True, reform=valid_reform,
+                  assump=valid_assump)
+    required_param_keys = {"policy", "consumption", "growdiff_baseline",
+                           "growdiff_response", "behavior"}
+    assert set(tb.params.keys()) == required_param_keys
+    with pytest.raises(ValueError):
+        TaxBrain(2018, 2020, use_cps=True, assump=invalid_assump)
+    invalid_assump = {
+        "consumption": {},
+        "growdiff_baseline": {},
+        "growdiff_response": {},
+        "invalid": {}
+    }
+    with pytest.raises(ValueError):
+        TaxBrain(2018, 2020, use_cps=True, assump=invalid_assump)
+    with pytest.raises(TypeError):
+        TaxBrain(2018, 2020, use_cps=True, reform=True)
+    with pytest.raises(TypeError):
+        TaxBrain(2018, 2020, use_cps=True, assump=True)

--- a/taxbrain/tests/test_brain.py
+++ b/taxbrain/tests/test_brain.py
@@ -46,7 +46,7 @@ def test_distribution_table(tb_static):
                                      "expanded_income", "nonreform")
 
 
-def test_user_input(reform_json_str):
+def test_user_input(reform_json_str, assump_json_str):
     valid_reform = {
         2019: {
             "_II_rt7": [0.40]
@@ -65,6 +65,8 @@ def test_user_input(reform_json_str):
         "growdiff_response": {}
     }
     TaxBrain(2018, 2019, use_cps=True, assump=valid_assump)
+    TaxBrain(2018, 2019, use_cps=True, reform=reform_json_str,
+             assump=assump_json_str)
     tb = TaxBrain(2018, 2019, use_cps=True, reform=valid_reform,
                   assump=valid_assump)
     required_param_keys = {"policy", "consumption", "growdiff_baseline",


### PR DESCRIPTION
This PR adds a private method to the TaxBrain class that will handle processing user input. The benefit of this PR is now users can pass in Tax-Calculator-ready dictionaries for reforms and assumptions, rather than just JSON strings. It is just adding a little bit of extra flexibility to the model. This will have no effect on the TBI.