### PR TITLE
Modify dynamic simulations for behresp 0.6.0

### DIFF
--- a/taxbrain/tests/test_brain.py
+++ b/taxbrain/tests/test_brain.py
@@ -17,11 +17,13 @@ def test_arg_validation():
 
 
 def test_static_run(tb_static):
+    with pytest.raises(TypeError):
+        tb_static.run(dict())
     tb_static.run()
 
 
 def test_dynamic_run(tb_dynamic):
-    tb_dynamic.run({2018: {"BE_sub": 0.25}})
+    tb_dynamic.run()
 
 
 def test_weighted_totals(tb_static):


### PR DESCRIPTION
This PR modifies the dynamic simulations to work with version 0.6.0 of `behresp` package. The `trace` argument for `response` was changed to `dump`. Without this PR `dump` would only be true if the user specifies `verbose` as true when initiating the TaxBrain class.

It also defaults to setting `dump` to true so that a user can pick which variables to save on a run.