### PR TITLE
Add numpy to meta.yaml

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -9,6 +9,7 @@ requirements:
     - behresp
     - pandas
     - dask
+    - numpy
 
 run:
   - python
@@ -16,6 +17,7 @@ run:
   - behresp
   - pandas
   - dask
+  - numpy
 
 test:
   imports:


### PR DESCRIPTION
This PR adds a numpy to the list of packages required to build and run the taxbrain package. All of the packages listed in the environment, setup, and meta files are now in sync so hopefully this will solve the packaging issues I've been having.