### PR TITLE
Specify Package Requirements

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -6,18 +6,18 @@ requirements:
   build:
     - python
     - "taxcalc>1.0.0"
-    - behresp
-    - pandas
+    - "behresp>=0.6.0"
+    - "pandas>=0.23"
     - dask
-    - numpy
+    - "numpy>=1.13"
 
 run:
   - python
   - "taxcalc>1.0.0"
-  - behresp
-  - pandas
+  - "behresp>=0.6.0"
+  - "pandas>=0.23"
   - dask
-  - numpy
+  - "numpy>=1.13"
 
 test:
   imports:

--- a/environment.yml
+++ b/environment.yml
@@ -4,8 +4,8 @@ channels:
 dependencies:
 - python>=3.6.5
 - taxcalc>=1.0.0
-- behresp
-- pandas
-- numpy
+- behresp>=0.6.0
+- pandas>=0.23
+- numpy>=1.13
 - pytest
 - dask


### PR DESCRIPTION
After added numpy to `meta.yaml` I received a new error when trying to build the package about a conflict between the version of numpy required by Tax-Calculator (1.13) and the default numpy version installed when building the package (1.11). This PR adds specific version requirements for numpy, pandas, and behresp to hopefully avoid that issue.