### PR TITLE
Remove import test

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,9 +19,5 @@ run:
   - dask
   - "numpy>=1.13"
 
-test:
-  imports:
-    - taxbrain
-
 about:
   home: https://github.com/PSLmodels/Tax-Brain


### PR DESCRIPTION
This PR removes the import test from `meta.yaml`. I'm doing this to try and squeeze out other bugs in the files used to build the conda package.