### PR TITLE
Indent run section, remove reqs from setup.py

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -11,13 +11,17 @@ requirements:
     - dask
     - "numpy>=1.13"
 
-run:
-  - python
-  - "taxcalc>1.0.0"
-  - "behresp>=0.6.0"
-  - "pandas>=0.23"
-  - dask
-  - "numpy>=1.13"
+  run:
+    - python
+    - "taxcalc>1.0.0"
+    - "behresp>=0.6.0"
+    - "pandas>=0.23"
+    - dask
+    - "numpy>=1.13"
+
+test:
+  imports:
+    - taxbrain
 
 about:
   home: https://github.com/PSLmodels/Tax-Brain

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setuptools.setup(
     long_description=long_description,
     url="https://github.com/PSLmodels/Tax-Brain",
     packages=["taxbrain", "taxbrain.tbi"],
-    install_requires=["taxcalc", "behresp", "pandas", "dask", "numpy"],
+    install_requires=[],
     tests_require=["pytest"],
     license="MIT"
 )


### PR DESCRIPTION
This PR hopefully resolves our build woes. I indented the run section. Then, I got the following error:

```
  File "/home/henrydoupe/anaconda3/envs/pkgbld-dev/conda-bld/taxbrain_1552402157879/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/python3.6/site-packages/setuptools/package_index.py", line 326, in process_url
    "Be sure to add all dependencies in the meta.yaml  url=%s" % url)
RuntimeError: Setuptools downloading is disabled in conda build. Be sure to add all dependencies in the meta.yaml  url=https://pypi.org/simple/Jinja2/
```

There seemed to be an issue with specifying packages in `setup.py`. So, I removed the requiremets specified in `install_requires` and the local build worked!

```
(pkgbld-dev) henrydoupe@henry-mac:~/Documents/Package-Builder$ pbrelease Tax-Brain taxbrain 2.0.0 --local $PWD/../Tax-Brain
: Package-Builder will build model packages for:
:   repository_name = Tax-Brain
:   package_name = taxbrain
:   model_version = 2.0.0
:   python_versions = ['3.6']
: Package-Builder will upload model packages to:
:   Anaconda channel = pslmodels
:   using token in file = /home/henrydoupe/.pslmodels_anaconda_token
: Package-Builder is starting at Tue Mar 12 10:55:22 2019
: Package-Builder is setting version
: Package-Builder is building package for Python 3.6
running cmd:  conda build --python 3.6 --old-build-string --channel pslmodels --override-channels --no-anaconda-upload --output-folder pkgbld_output conda.recipe
No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
WARNING:conda_build.metadata:No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.11
INFO:conda_build.variants:Adding in variants from internal_defaults
INFO:conda_build.variants:Adding in variants from config.variant
INFO:conda_build.metadata:Attempting to finalize metadata for taxbrain
WARNING: symlink_conda() is deprecated.
zip_safe flag not set; analyzing archive contents...
taxbrain.tbi.__pycache__.tbi.cpython-36: module references __file__
INFO:conda_build.build:Packaging taxbrain
INFO:conda_build.build:Packaging taxbrain-2.0.0-py36_0
nm: dynamic_annotations.o: no symbols
Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
WARNING:conda_build.build:Importing conda-verify failed.  Please be sure to test your packages.  conda install conda-verify to make this message go away.
INFO:conda_build.variants:Adding in variants from /tmp/tmpv0v5wvjs/info/recipe/conda_build_config.yaml
WARNING: symlink_conda() is deprecated.
: Package-Builder is converting package for Python 3.6
: Package-Builder is uploading packages for Python 3.6
: Package-Builder is cleaning-up
: Package-Builder is finishing at Tue Mar 12 10:57:25 2019
(pkgbld-dev) henrydoupe@henry-mac:~/Documents/Package-Builder$ 
```

Note: I did this with a [modified version](https://github.com/PSLmodels/Package-Builder/compare/master...hdoupe:local-build) of Package-Builder. @andersonfrailey want to do a full run with these changes?