### PR TITLE
Modify TBI to work with new behavioral-responses and taxcalc packages

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -7,7 +7,7 @@ using Tax-Brain starts by importing and creating a `TaxBrain` instance.
 from taxbrain import TaxBrain
 
 tb = TaxBrain(2019, 2029, use_cps=True, reform="reform.json",
-              assump="assumptions.json", behavior={2019: {"BE_sub": 0.25}})
+              assump="assumptions.json", behavior={"sub": 0.25})
 ```
 
 `TaxBrain` takes the following arguments on initialization:

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,14 +5,14 @@ package:
 requirements:
   build:
     - python
-    - "taxcalc>1.0.0"
-    - "behresp>=0.6.0"
+    - "taxcalc>1.1.0"
+    - "behresp>=0.7.0"
     - dask
 
   run:
     - python
-    - "taxcalc>1.0.0"
-    - "behresp>=0.6.0"
+    - "taxcalc>1.1.0"
+    - "behresp>=0.7.0"
     - dask
 
 about:

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,8 @@ channels:
 - PSLmodels
 dependencies:
 - python>=3.6.5
-- taxcalc>=1.0.0
-- behresp>=0.6.0
+- taxcalc>=1.1.0
+- behresp>=0.7.0
 - pandas>=0.23
 - numpy>=1.13
 - pytest

--- a/example.ipynb
+++ b/example.ipynb
@@ -548,7 +548,7 @@
    "outputs": [],
    "source": [
     "tb_dynamic = TaxBrain(2019, 2028, use_cps=True, reform=reform_url,\n",
-    "                      behavior={2019: {\"BE_sub\": 0.25}})\n",
+    "                      behavior={\"sub\": 0.25})\n",
     "tb_dynamic.run()"
    ]
   },

--- a/example.py
+++ b/example.py
@@ -16,7 +16,7 @@ static_time = time.time() - static_start
 
 # run dynamic analysis
 tb_dynamic = TaxBrain(2019, 2028, use_cps=True, reform=reform_url,
-                      behavior={2019: {"BE_sub": 0.25}})
+                      behavior={"sub": 0.25})
 dynamic_start = time.time()
 tb_dynamic.run()
 dynamic_table = tb_dynamic.weighted_totals("c00100")

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,6 @@ setuptools.setup(
         "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: MIT License",
         "Opperating Sytem :: OS Independent"
-    ]
+    ],
+    include_package_data=True
 )

--- a/taxbrain/tbi/behavior_params.json
+++ b/taxbrain/tbi/behavior_params.json
@@ -14,9 +14,7 @@
                 "min": 0.0,
                 "max": 9e+99
             }
-        },
-        "boolean_value": false,
-        "integer_value": false
+        }
     },
     "inc": {
         "title": "Income elasticity of taxable income",
@@ -33,9 +31,7 @@
                 "min": -9e+99,
                 "max": 0.0
             }
-        },
-        "boolean_value": false,
-        "integer_value": false
+        }
     },
     "cg": {
         "title": "Semi-elasticity of long-term capital gains",
@@ -52,8 +48,6 @@
                 "min": -9e+99,
                 "max": 0.0
             }
-        },
-        "boolean_value": false,
-        "integer_value": false
+        }
     }
 }

--- a/taxbrain/tbi/behavior_params.json
+++ b/taxbrain/tbi/behavior_params.json
@@ -1,0 +1,59 @@
+{
+    "sub": {
+        "title": "Substitution elasticity of taxable income",
+        "description": "Defined as proportional change in taxable income divided by proportional change in marginal net-of-tax rate (1-MTR) on taxpayer earnings caused by the reform.  Must be zero or positive.",
+        "section_1": "Behavior",
+        "section_2": "",
+        "notes": "",
+        "type": "float",
+        "value": [
+            0.0
+        ],
+        "validators": {
+            "range": {
+                "min": 0.0,
+                "max": 9e+99
+            }
+        },
+        "boolean_value": false,
+        "integer_value": false
+    },
+    "inc": {
+        "title": "Income elasticity of taxable income",
+        "description": "Defined as dollar change in taxable income divided by dollar change in after-tax income caused by the reform.  Must be zero or negative.",
+        "section_1": "Behavior",
+        "section_2": "",
+        "notes": "",
+        "type": "float",
+        "value": [
+            0.0
+        ],
+        "validators": {
+            "range": {
+                "min": -9e+99,
+                "max": 0.0
+            }
+        },
+        "boolean_value": false,
+        "integer_value": false
+    },
+    "cg": {
+        "title": "Semi-elasticity of long-term capital gains",
+        "description": "Defined as change in logarithm of long-term capital gains divided by change in marginal tax rate (MTR) on long-term capital gains caused by the reform.  Must be zero or negative.  Read response function documentation (see below) for discussion of appropriate values.",
+        "section_1": "Behavior",
+        "section_2": "",
+        "notes": "",
+        "type": "float",
+        "value": [
+            0.0
+        ],
+        "validators": {
+            "range": {
+                "min": -9e+99,
+                "max": 0.0
+            }
+        },
+        "boolean_value": false,
+        "integer_value": false
+    }
+}

--- a/taxbrain/tbi/tbi.py
+++ b/taxbrain/tbi/tbi.py
@@ -26,7 +26,6 @@ import numpy as np
 import pandas as pd
 from operator import itemgetter
 from collections import defaultdict
-from behresp import PARAM_INFO
 from taxcalc import (Policy, Records, Calculator,
                      Consumption, GrowFactors, GrowDiff,
                      DIST_TABLE_LABELS, DIFF_TABLE_LABELS,

--- a/taxbrain/tests/conftest.py
+++ b/taxbrain/tests/conftest.py
@@ -45,7 +45,7 @@ def tb_static(reform_json_str):
 @pytest.fixture(scope="session")
 def tb_dynamic(reform_json_str):
     return TaxBrain(2018, 2019, use_cps=True, reform=reform_json_str,
-                    behavior={2018: {"BE_sub": 0.25}})
+                    behavior={"sub": 0.25})
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
As the title says, this PR makes the needed modifications to work with the latest Behavioral-Responses and Tax-Calculator packages. Since Behavioral-Responses removed the `PARAM_INFO` variable I had to create a new JSON file to store all of the information needed to properly display and validate user input. I've also added a new function to handle the validation. I'll be updating examples and documentation shortly.

cc @hdoupe 