### PR TITLE
Fix bug in distribution table function

### DIFF
--- a/taxbrain/taxbrain.py
+++ b/taxbrain/taxbrain.py
@@ -218,6 +218,9 @@ class TaxBrain:
         data["num_returns_AMT"] = data["s006"].where(
             data["c09600"] > 0., 0.
         )
+        if income_measure == "expanded_income_baseline":
+            base_income = self.base_data[year]["expanded_income"]
+            data["expanded_income_baseline"] = base_income
         table = create_distribution_table(data, groupby, income_measure)
         return table
 

--- a/taxbrain/tests/test_brain.py
+++ b/taxbrain/tests/test_brain.py
@@ -49,7 +49,7 @@ def test_differences_table(tb_dynamic):
 
 def test_distribution_table(tb_static):
     table = tb_static.distribution_table(2019, "weighted_deciles",
-                                         "expanded_income", "reform")
+                                         "expanded_income_baseline", "reform")
     assert isinstance(table, pd.DataFrame)
     table = tb_static.distribution_table(2019, "weighted_deciles",
                                          "expanded_income", "base")


### PR DESCRIPTION
This PR fixes a bug in the distribution table function that would cause an error if the user ever specified `expanded_income_baseline` as the `income_measure` argument in TaxBrain's `distribution_table` method.