### PR TITLE
Remove ParamTools requirement

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -8,8 +8,6 @@ requirements:
     - "taxcalc>2.2.0"
     - "behresp>=0.7.0"
     - dask
-    - paramtools
-    - marshmallow
 
   run:
     - python
@@ -17,8 +15,6 @@ requirements:
     - "behresp>=0.7.0"
     - dask
     - bokeh
-    - paramtools
-    - marshmallow
 
 about:
   home: https://github.com/PSLmodels/Tax-Brain

--- a/environment.yml
+++ b/environment.yml
@@ -1,7 +1,6 @@
 name: taxbrain-dev
 channels:
 - PSLmodels
-- conda-forge
 dependencies:
 - python>=3.6.5
 - taxcalc>=2.2.0
@@ -11,7 +10,5 @@ dependencies:
 - pytest
 - dask
 - bokeh
-- paramtools
-- marshmallow
 - pip:
   - compdevkit

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 import setuptools
 
-install_requires = ["taxcalc", "behresp", "dask", "paramtools", "marshmallow",
-                    "bokeh"]
+install_requires = ["taxcalc", "behresp", "dask", "bokeh"]
 
 with open("README.md", "r") as f:
     long_description = f.read()


### PR DESCRIPTION
This PR removes ParamTools as a requirement for Tax-Brain since Tax-Brain itself doesn't use it, only the `compconfig` package does. `compconfig` is not included in the `Tax-Brain` package so there's no need to include it as a requirement.