### PR TITLE
Update dynamic run requirements

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -6,13 +6,13 @@ requirements:
   build:
     - python
     - "taxcalc>=2.2.0"
-    - "behresp>=0.7.0"
+    - "behresp>=0.8.0"
     - dask
 
   run:
     - python
     - "taxcalc>=2.2.0"
-    - "behresp>=0.7.0"
+    - "behresp>=0.8.0"
     - dask
     - bokeh
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,7 +4,7 @@ channels:
 dependencies:
 - python>=3.6.5
 - taxcalc>=2.2.0
-- behresp>=0.7.0
+- behresp>=0.8.0
 - pandas>=0.23
 - numpy>=1.13
 - pytest

--- a/taxbrain/taxbrain.py
+++ b/taxbrain/taxbrain.py
@@ -283,36 +283,16 @@ class TaxBrain:
         """
         Run a dynamic response
         """
-        delay_list = []
+        if "s006" not in varlist:  # ensure weight is always included
+            varlist.append("s006")
         for year in range(self.start_year, self.end_year + 1):
-            delay = delayed(self._run_dynamic_calc)(self.base_calc,
-                                                    self.reform_calc,
-                                                    self.params["behavior"],
-                                                    year, varlist)
-            delay_list.append(delay)
-        compute(*delay_list)
-        del delay_list
-
-    def _run_dynamic_calc(self, calc1, calc2, behavior, year, varlist):
-        """
-        Function used to parallelize the dynamic run function
-
-        Parameters
-        ----------
-        calc1: Calculator object representing the baseline policy
-        calc2: Calculator object representing the reform policy
-        year: year for the calculations
-        """
-        calc1_copy = copy.deepcopy(calc1)
-        calc2_copy = copy.deepcopy(calc2)
-        calc1_copy.advance_to_year(year)
-        calc2_copy.advance_to_year(year)
-        # use response function to capture dynamic effects
-        base, reform = behresp.response(calc1_copy, calc2_copy,
-                                        behavior, dump=True)
-        self.base_data[year] = base[varlist]
-        self.reform_data[year] = reform[varlist]
-        del calc1_copy, calc2_copy, base, reform
+            self.base_calc.advance_to_year(year)
+            self.reform_calc.advance_to_year(year)
+            base, reform = behresp.response(self.base_calc, self.reform_calc,
+                                            self.params["behavior"],
+                                            dump=True)
+            self.base_data[year] = base[varlist]
+            self.reform_data[year] = reform[varlist]
 
     def _process_user_mods(self, reform, assump):
         """


### PR DESCRIPTION
This PR makes a few changes related to the dynamic runs of Tax-Brain.

First, it ups the requirements for the Behavioral-Responses package to 0.8.0. I didn't realize that the 2.2.0 release of Tax-Calc broke backwards compatibility with Behavioral-Response and thus didn't make this change before the Tax-Brain 2.2.0 release.

Second, it changes the `TaxBrain._dynamic_run` method run sequentially, rather than in parallel. Having it run in parallel with a bunch of copies of Calculator objects required massive memory resources and this was preventing the latest version of Tax-Brain to be uploaded to COMP.