### PR TITLE
Fix COMP table row order

### DIFF
--- a/compconfig/compconfig/functions.py
+++ b/compconfig/compconfig/functions.py
@@ -98,7 +98,8 @@ def validate_inputs(meta_params_dict, adjustment, errors_warnings):
         meta_params.adjust(meta_params_dict)
 
         tc_adj = {
-            "policy": convert_adj(adjustment["policy"], meta_params.year.tolist()),
+            "policy": convert_adj(adjustment["policy"],
+                                  meta_params.year.tolist()),
             "behavior": convert_behavior_adj(adjustment["behavior"])
         }
         res = errors_warnings, tc_adj

--- a/compconfig/compconfig/helpers.py
+++ b/compconfig/compconfig/helpers.py
@@ -333,7 +333,7 @@ def nth_year_results(tb, year, user_mods, fuzz, return_html=True):
         for id in sres:
             res[id] = [{
                 'dimension': year,
-                'raw': sres[id].to_json()
+                'raw': sres[id]
             }]
         elapsed_time = time.time() - start_time
         print('elapsed time for this run: {:.1f}'.format(elapsed_time))
@@ -386,7 +386,7 @@ def postprocess(data_to_process):
     for id, pdfs in data_to_process.items():
         if id.startswith('aggr'):
             pdfs.sort(key=year_getter)
-            tbl = pd.read_json(pdfs[0]["raw"])
+            tbl = pdfs[0]["raw"]
             tbl.index = pd.Index(RESULTS_TOTAL_ROW_KEY_LABELS[i]
                                  for i in tbl.index)
             # format table
@@ -411,7 +411,7 @@ def postprocess(data_to_process):
         else:
             for i in pdfs:
                 year = i["dimension"]
-                tbl = label_columns(pd.read_json(i['raw']))
+                tbl = label_columns(i["raw"])
                 title = '{} ({})'.format(RESULTS_TABLE_TITLES[id],
                                          year)
                 # format table

--- a/compconfig/compconfig/outputs.py
+++ b/compconfig/compconfig/outputs.py
@@ -79,18 +79,18 @@ def aggregate_plot(tb):
     fig.add_tools(ii_hover, proll_hover, combined_hover)
 
     # toggle which lines are shown
-    js = """
+    plot_js = """
     object1.visible = toggle.active
     object2.visible = toggle.active
     object3.visible = toggle.active
     """
-    base_callback = CustomJS.from_coffeescript(code=js, args={})
+    base_callback = CustomJS.from_coffeescript(code=plot_js, args={})
     base_toggle = Toggle(label="Base", button_type="primary",
                          callback=base_callback, active=True)
     base_callback.args = {"toggle": base_toggle, "object1": ii_base,
                           "object2": proll_base, "object3": comb_base}
 
-    reform_callback = CustomJS.from_coffeescript(code=js, args={})
+    reform_callback = CustomJS.from_coffeescript(code=plot_js, args={})
     reform_toggle = Toggle(label="Reform", button_type="primary",
                            callback=reform_callback, active=True)
     reform_callback.args = {"toggle": reform_toggle, "object1": ii_reform,


### PR DESCRIPTION
In issue #42 @donboyd5 pointed out that the order of the income bins in the distribution tables was being mixed up. Rather than appearing in order of ascending income, they appeared randomly. This PR fixes that issue.

Currently, after each table is made in the `nth_year_results` function, they are converted from a pandas DataFrame to a JSON string. Later on, they are converted back to a pandas DataFrame at which point the rows are somehow shuffled. I believe this dates back to TaxBrain 1.0.0.

In this PR I've removed the conversion of the original DataFrame so that the rows are never shuffled.

cc @hdoupe 