### PR TITLE
Fix extend capability and use instance value instead of '_vals' value

### DIFF
--- a/compconfig/compconfig/helpers.py
+++ b/compconfig/compconfig/helpers.py
@@ -108,6 +108,12 @@ def convert_defaults(pcl):
 
 
 def convert_adj(adj, start_year):
+    type_map = {
+        "real": float,
+        "boolean": bool,
+        "integer": int,
+        "string": str,
+    }
     pol = Policy()
     new_adj = defaultdict(dict)
     for param, valobjs in adj.items():
@@ -136,7 +142,11 @@ def convert_adj(adj, start_year):
                 else:
                     year_ix = valobj["year"] - min(param_meta["value_yrs"])
                     # shallow copy the list
-                    defaultlist = list(param_meta["value"][year_ix])
+                    type_func = type_map[param_meta["value_type"]]
+                    # convert from numpy type to basic python type.
+                    defaultlist = list(
+                        map(type_func, getattr(pol, f"_{param}")[year_ix])
+                    )
 
                 defaultlist[other_label_ix] = valobj["value"]
 
@@ -145,6 +155,8 @@ def convert_adj(adj, start_year):
                 msg = (f"Dict should have 2 or 3 keys. It has {len(valobj)}"
                        f"instead (key={list(valobj.keys())}).")
                 raise ValueError(msg)
+            # make sure values are updated so that extend logic works.
+            pol.implement_reform(new_adj)
     return new_adj
 
 

--- a/compconfig/compconfig/tests/test_functions.py
+++ b/compconfig/compconfig/tests/test_functions.py
@@ -2,7 +2,7 @@ import copy
 
 from compdevkit import FunctionsTest
 
-from compconfig import functions
+from compconfig import functions, helpers
 
 
 def test_functions():
@@ -16,7 +16,8 @@ def test_functions():
             ],
             "CPI_offset": [
                 {"year": 2019, "value": -0.001}
-            ]
+            ],
+            "EITC_c": [{"EIC": "0kids", "year": 2019, "value": 1000.0}],
         },
         "behavior": {
             "inc": [
@@ -71,3 +72,32 @@ def test_checkbox_params():
     assert functions.validate_inputs({}, copy.deepcopy(adj), errors_warnings)
 
     assert functions.run_model({"use_full_sample": False, "data_source": "CPS"}, adj)
+
+
+def test_convert_adj():
+    adj = {
+        "STD": [
+            {"MARS": "single", "year": 2019, "value": 0},
+            {"MARS": "mjoint", "year": 2019, "value": 1},
+            {"MARS": "mjoint", "year": 2022, "value": 10}
+        ],
+        "CPI_offset": [
+            {"year": 2019, "value": -0.001}
+        ],
+        "EITC_c": [{"EIC": "0kids", "year": 2019, "value": 1000.0}],
+    }
+
+    res = helpers.convert_adj(adj, 2019)
+
+    assert res == {
+        "STD": {
+            2019: [0, 1, 12268.8, 18403.2, 24537.6],
+            2022: [0, 10, 13081.03, 19621.54, 26162.06]
+        },
+        "CPI_offset": {
+            2019: -0.001
+        },
+        "EITC_c": {
+            2019: [1000.0, 3529.87, 5829.75, 6558.98]
+        }
+    }


### PR DESCRIPTION
Resolves #57. This PR fixes a bug in Tax-Brain's compconfig package's where the parameters are converted from the ParamTools format to the Tax-Calculator format. An example for what this conversion function does can be found in [`compconfig/compconfit/tests/test_functions.py`](https://github.com/hdoupe/Tax-Brain/blob/f6bcbe3c8989fc24fde451502c790dcabe639668/compconfig/compconfig/tests/test_functions.py#L77-L103)