### PR TITLE
Use ParamTools 0.7.0 to fix extend bugs

### DIFF
--- a/compconfig/compconfig/functions.py
+++ b/compconfig/compconfig/functions.py
@@ -27,6 +27,7 @@ CUR_PATH = os.path.abspath(os.path.dirname(__file__))
 
 class TCParams(paramtools.Parameters):
     defaults = RES
+    label_to_extend = "year"
 
 
 class BehaviorParams(paramtools.Parameters):
@@ -90,6 +91,9 @@ def validate_inputs(meta_params_dict, adjustment, errors_warnings):
     behavior_params = BehaviorParams()
     behavior_params.adjust(adjustment["behavior"], raise_errors=False)
     errors_warnings["behavior"]["errors"].update(behavior_params.errors)
+
+    if policy_params.errors or behavior_params.errors:
+        return errors_warnings
 
     # try to parse to the correct Tax-Calculator format.
     try:

--- a/compconfig/compconfig/tests/test_functions.py
+++ b/compconfig/compconfig/tests/test_functions.py
@@ -35,7 +35,8 @@ def test_functions():
             ],
             "CPI_offset": [
                 {"year": 2019, "value": -0.001}
-            ]
+            ],
+            "ACTC_c": [{"year": 2019, "value": 2000.0}],
         },
         "behavior": {
             "sub": [

--- a/compconfig/install.sh
+++ b/compconfig/install.sh
@@ -1,3 +1,3 @@
 # bash commands for installing your package
 BUILD_NUM=1
-conda install -c pslmodels -c conda-forge nodejs taxbrain "paramtools>=0.5.4"
+conda install -c pslmodels -c conda-forge nodejs taxbrain "paramtools>=0.7.0"


### PR DESCRIPTION
Resolves #62. ParamTools 0.7.0 adds the ability to extend the [default parameters and user adjustments along a label such as "year."](https://paramtools.org/api/extend/) This should put ParamTools validation very close in line with Tax-Calculator's validation. The only exception is if a parameter's value inflates out of the range of valid values. However, I expect this to be an edge case and, further, this capability will be added to ParamTools soon.