### PR TITLE
Apply index parameters before other parameters

### DIFF
--- a/compconfig/compconfig/helpers.py
+++ b/compconfig/compconfig/helpers.py
@@ -116,10 +116,19 @@ def convert_adj(adj, start_year):
     }
     pol = Policy()
     new_adj = defaultdict(dict)
+    # Update all indexing fields first. This ensures that all indexing rules
+    # are set before adjusting the parameters they affect.
     for param, valobjs in adj.items():
         if param.endswith("checkbox"):
             param_name = param.split("_checkbox")[0]
             new_adj[f"{param_name}-indexed"][start_year] = valobjs[0]["value"]
+            pol.implement_reform(
+                {f"{param_name}-indexed": {start_year: valobjs[0]["value"]}},
+                raise_errors=False
+            )
+            continue
+    for param, valobjs in adj.items():
+        if param.endswith("checkbox"):
             continue
         for valobj in valobjs:
             if not (set(valobj.keys()) -
@@ -158,7 +167,7 @@ def convert_adj(adj, start_year):
                 new_adj[param][valobj["year"]] = defaultlist
 
             # make sure values are updated so that extend logic works.
-            pol.implement_reform(new_adj)
+            pol.implement_reform(new_adj, raise_errors=False)
     return new_adj
 
 

--- a/compconfig/compconfig/tests/test_functions.py
+++ b/compconfig/compconfig/tests/test_functions.py
@@ -107,3 +107,29 @@ def test_convert_adj():
             2019: True
         }
     }
+
+def test_convert_adj_w_index():
+    adj = {
+        "ACTC_c": [
+            {"year": 2019, "value": 2000.0},
+            {"year": 2026, "value": 1000.0}
+        ],
+        "STD": [
+            {"year": 2019, "MARS": "single", "value": 2000.0},
+            {"year": 2020, "MARS": "mjoint", "value": 12345},
+            {"year": 2026, "MARS": "single", "value": 1000.0}
+        ],
+        "STD_checkbox": [{"value": False}]
+    }
+    res = helpers.convert_adj(adj, 2019)
+    assert res == {
+        "STD-indexed": {
+            2019: False
+        },
+        "ACTC_c": {2019: 2000.0, 2026: 1000.0},
+        "STD": {
+            2019: [2000.0, 24537.6, 12268.8, 18403.2, 24537.6],
+            2020: [2000.0, 12345, 12268.8, 18403.2, 24537.6],
+            2026: [1000.0, 12345.0, 12268.8, 18403.2, 24537.6]
+        }
+    }


### PR DESCRIPTION
The following reform was not converted correctly:

```json
adj = {
    "ACTC_c": [
        {"year": 2019, "value": 2000.0},
        {"year": 2026, "value": 1000.0}
    ],
    "STD": [
        {"year": 2019, "MARS": "single", "value": 2000.0},
        {"year": 2020, "MARS": "mjoint", "value": 12345},
        {"year": 2026, "MARS": "single", "value": 1000.0}
    ],
    "STD_checkbox": [{"value": false}]
}
```
It appeared that indexing was not turned off for the STD parameter since values like 2000 were increased in years after it was set:

```json
{
    "ACTC_c": {2019: 2000.0, 2026: 1000.0},
    "STD": {
        2019: [2000.0, 24537.6, 12268.8, 18403.2, 24537.6],
        2020: [2037.2, 12345, 12497.0, 18745.5, 24994.0],
        2026: [1000.0, 14081.96, 14255.34, 21383.0, 28510.66]},
    "STD-indexed": {2019: false}
}
```

It turned out that `STD-indexed` was only applied after the values were converted for the `STD` parameter. This PR applies all changes to indexing rules before converting the other parameters.