### PR TITLE
Add CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__/
 .ipynb_checkpoints/
 dist/
 build/
+dask-worker-space

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,14 +1,22 @@
 # Tax-Brain Release History
 
-## 2019-06-03 Release 2.2.2
+## 2019-xx-xx Release x.x.x
 
-Last Merged Pull Request: [#54](https://github.com/PSLmodels/Tax-Brain/pull/54)
+Last Merged Pull Request: [#67](https://github.com/PSLmodels/Tax-Brain/pull/67)
 
 Changes in this release:
 
 * Refactor the `run()` method and TaxBrain initialization process so that
   calculator objects are not created until `run()` is called ([#44](https://github.com/PSLmodels/Tax-Brain/pull/44))
 * Modify `metaparams` in the `COMPconfig` ([#54](https://github.com/PSLmodels/Tax-Brain/pull/54))
+* Fix various COMP bugs ([#58](https://github.com/PSLmodels/Tax-Brain/pull/58),
+  [#60](https://github.com/PSLmodels/Tax-Brain/pull/60),
+  [#63](https://github.com/PSLmodels/Tax-Brain/pull/63),
+  [#65](https://github.com/PSLmodels/Tax-Brain/pull/65))
+* Allow users to specify an alternative policy to use as the baseline, rather
+  than current law ([#64](https://github.com/PSLmodels/Tax-Brain/pull/64))
+* Update COMP table outputs so they are more readable ([#66](https://github.com/PSLmodels/Tax-Brain/pull/66))
+* Add TaxBrain command line interface ([#67](https://github.com/PSLmodels/Tax-Brain/pull/67))
 
 ## 2019-05-24 Release 2.2.1
 

--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,10 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Opperating Sytem :: OS Independent"
     ],
-    include_package_data=True
+    include_package_data=True,
+    entry_points={
+        "console_scripts": [
+            "taxbrain = taxbrain.cli:cli_main"
+        ]
+    }
 )

--- a/taxbrain/__init__.py
+++ b/taxbrain/__init__.py
@@ -1,4 +1,5 @@
 from taxbrain.taxbrain import *
 from taxbrain.utils import *
+from taxbrain.cli import *
 
 __version__ = "0.0.0"


### PR DESCRIPTION
This PR adds a command line interface for Tax-Brain. It provides an alternative to the python API or COMP web app. The only required arguments are a start and end year. Here is the output from `taxbrain -h`:

```
usage: taxbrain [-h] [--data DATA] [--usecps] [--reform REFORM]
                [--behavior BEHAVIOR] [--assump ASSUMP] [--baseline BASELINE]
                [--outdir OUTDIR] [--name NAME]
                startyear endyear

This is the command line interface for the taxbrain package.

positional arguments:
  startyear            startyear is the first year of the analysis you want to
                       run.
  endyear              endyear is the last year of the analysis you want to
                       run.

optional arguments:
  -h, --help           show this help message and exit
  --data DATA          The file path to a micro-dataset that is formatted for
                       use in Tax-Calculator.
  --usecps             If this argument is present, the CPS file included in
                       Tax-Calculator will be used for the analysis.
  --reform REFORM      --reform should be a path to a JSON file.
  --behavior BEHAVIOR  --behavior should be a path to a JSON file containing
                       behavioral assumptions.
  --assump ASSUMP      --assump should be a path to a JSON file containing
                       user specified economic assumptions.
  --baseline BASELINE  --baseline should be a path to a JSON file containing a
                       policy that will be used as the baseline of the
                       analysis
  --outdir OUTDIR      outdir is the name of the output directory. Not
                       including --outdir will result in files being written
                       to the current directory.
  --name NAME          Name of the analysis. This will be used to name the
                       directory where all output files will be written.
```