### PR TITLE
COMP build: Ensure Tax-Brain version is at least 2.3.2

### DIFF
--- a/compconfig/install.sh
+++ b/compconfig/install.sh
@@ -1,3 +1,3 @@
 # bash commands for installing your package
 BUILD_NUM=1
-conda install -c pslmodels -c conda-forge nodejs taxbrain "paramtools>=0.7.0"
+conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "paramtools>=0.7.0"


### PR DESCRIPTION
For some reason, conda is installing Tax-Brain 2.3.0 even though 2.3.2 is available. This is only an issue when running the comp build scripts. When I install Tax-Brain just using my normal conda environment, Tax-Brain 2.3.2 is installed.