### PR TITLE
Add pandoc to `install.sh` per build error

### DIFF
--- a/compconfig/install.sh
+++ b/compconfig/install.sh
@@ -1,3 +1,3 @@
 # bash commands for installing your package
 BUILD_NUM=1
-conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "paramtools>=0.7.0"
+conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "paramtools>=0.7.0" pandoc

--- a/compconfig/install.sh
+++ b/compconfig/install.sh
@@ -1,3 +1,3 @@
 # bash commands for installing your package
 BUILD_NUM=1
-conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "paramtools>=0.7.0" pandoc
+conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "paramtools>=0.7.0" pypandoc

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -22,6 +22,7 @@ requirements:
     - weasyprint
     - tabulate
     - selenium
+    - pypandoc
 
 about:
   home: https://github.com/PSLmodels/Tax-Brain

--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,6 @@ dependencies:
 - tabulate
 - weasyprint
 - selenium
+- pypandoc
 - pip:
   - compdevkit


### PR DESCRIPTION
I got this error when building Tax-Brain:

```python
______________________ ERROR collecting test_functions.py ______________________
ImportError while importing test module '/home/test_functions.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../test_functions.py:5: in <module>
    from compconfig import functions, helpers
/opt/conda/lib/python3.7/site-packages/compconfig/__init__.py:1: in <module>
    from .functions import *
/opt/conda/lib/python3.7/site-packages/compconfig/functions.py:7: in <module>
    from .constants import MetaParameters
/opt/conda/lib/python3.7/site-packages/compconfig/constants.py:4: in <module>
    from taxbrain import TaxBrain
/opt/conda/lib/python3.7/site-packages/taxbrain/__init__.py:3: in <module>
    from taxbrain.cli import *
/opt/conda/lib/python3.7/site-packages/taxbrain/cli.py:5: in <module>
    from taxbrain import TaxBrain, report
/opt/conda/lib/python3.7/site-packages/taxbrain/report.py:7: in <module>
    from .report_utils import (form_intro, form_baseline_intro, write_text, date,
/opt/conda/lib/python3.7/site-packages/taxbrain/report_utils.py:8: in <module>
    import pypandoc
E   ModuleNotFoundError: No module named 'pypandoc'
```