### PR TITLE
Update Install Requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,5 +18,7 @@ dependencies:
 - tabulate
 - weasyprint
 - selenium
+- pip
+- pypandoc
 - pip:
   - compdevkit


### PR DESCRIPTION
This PR updates some of the requirements for installing Tax-Brain as well as the `taxbrain-dev` environment. I'm hoping this solves some of the install issues we've had with the latest version of TaxBrain and by pinning the latest version of Tax-Calculator there should be no more issues with users who update the CPI offset and a CPI parameter.