### PR TITLE
Fix COMP Graph

### DIFF
--- a/compconfig/compconfig/outputs.py
+++ b/compconfig/compconfig/outputs.py
@@ -40,11 +40,11 @@ def aggregate_plot(tb):
                          line_color="#73bfe2", legend="Income Tax - Reform",
                          source=reform_cds)
     proll_base = fig.line(x="index", y="payrolltax", line_width=4,
-                          line_color="#98cf90", legend="Payroll Tax - Reform",
-                          source=reform_cds)
+                          line_color="#408941", legend="Payroll Tax - Base",
+                          source=base_cds)
     proll_reform = fig.line(x="index", y="payrolltax", line_width=4,
-                            line_color="#408941", legend="Payroll Tax - Base",
-                            source=base_cds)
+                            line_color="#98cf90", legend="Payroll Tax - Reform",
+                            source=reform_cds)
     comb_base = fig.line(x="index", y="combined", line_width=4,
                          line_color="#a4201d", legend="Combined - Base",
                          source=base_cds)

--- a/compconfig/install.sh
+++ b/compconfig/install.sh
@@ -1,3 +1,3 @@
 # bash commands for installing your package
 BUILD_NUM=1
-conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "paramtools>=0.7.0" pypandoc
+conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.5.0" "paramtools>=0.7.0" pypandoc


### PR DESCRIPTION
The graph that Tax-Brain produces for COMP has an error. When you click on the the "base" or "reform" buttons so that only one or the other set of lines is displayed, the baseline payroll tax line is displayed with the reform lines and the reform payroll tax line is displayed with the base lines.

The lines have always been labeled correctly and there are no issues with the accuracy of the graph.

Thanks to @Peter-Metz for pointing this bug out awhile back!

I also went ahead and updated the COMP install instructions to ensure that Tax-Calculator 2.5 or above would be installed.

cc @hdoupe 