### PR TITLE
Fix taxcalc/taxbrain version requirements

### DIFF
--- a/compconfig/install.sh
+++ b/compconfig/install.sh
@@ -1,3 +1,3 @@
 # bash commands for installing your package
 BUILD_NUM=1
-conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.5.0" "paramtools>=0.7.0" pypandoc
+conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "taxcalc>=2.5.0" "paramtools>=0.7.0" pypandoc


### PR DESCRIPTION
This sets the minimum required version of Tax-Brain to 2.3.2 and Tax-Calculator to 2.5.0 (the most up-to-date releases for each project).