### PR TITLE
Remove no-longer-needed tostring call

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -57,7 +57,7 @@ def get_inputs(meta_params_dict):
     policy_params = TCParams()
     policy_params.set_state(
         year=metaparams.year.tolist(),
-        data_source=metaparams.data_source.tolist(),
+        data_source=metaparams.data_source,
     )
     behavior_params = BehaviorParams()
 

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,2 +1,2 @@
 # bash commands for installing your package
-conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "taxcalc>=2.5.0" "paramtools>=0.7.0" pypandoc
+conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "taxcalc>=2.5.0" "paramtools>=0.10.2" pypandoc


### PR DESCRIPTION
ParamTools 0.10.2 no longer forces scalar values to be NumPy arrays. Thus, the `data_source` parameter on `MetaParams` no longer needs to be converted to a string in the `set_state` call.