### PR TITLE
Add nodejs and paramtools to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
 - behresp>=0.9.0
 - pandas>=0.23
 - numpy>=1.13
+- paramtools>=0.10.1
 - pytest
 - dask
 - bokeh
@@ -19,6 +20,8 @@ dependencies:
 - weasyprint
 - selenium
 - pypandoc
+- nodejs
 - pip
 - pip:
   - cs-kit
+  


### PR DESCRIPTION
This should take care of most of the errors when the tests are run. I still get an error when I run `test_report` but that doesn't seems to be a dependency issue.

Since the failing tests are no longer a concern, #89 is ready to be merged after review.

cc: @hdoupe @andersonfrailey 