### PR TITLE
Fix base policy handling

### DIFF
--- a/taxbrain/taxbrain.py
+++ b/taxbrain/taxbrain.py
@@ -87,7 +87,9 @@ class TaxBrain:
         self.params["behavior"] = behavior
         if base_policy:
             base_policy = self._process_user_mods(base_policy, None)
-        self.params["base_policy"] = base_policy
+            self.params["base_policy"] = base_policy["policy"]
+        else:
+            self.params["base_policy"] = None
 
         self.has_run = False
 

--- a/taxbrain/tests/test_brain.py
+++ b/taxbrain/tests/test_brain.py
@@ -25,6 +25,14 @@ def test_static_run(tb_static):
     tb_static.run()
 
 
+def test_baseline_policy():
+    base = {"II_em": {2019: 0}}
+    reform = {"II_em": {2025: 2000}}
+
+    tb = TaxBrain(2018, 2019, use_cps=True, reform=reform, base_policy=base)
+    tb.run()
+
+
 def test_dynamic_run(tb_dynamic):
     tb_dynamic.run()
 


### PR DESCRIPTION
This PR fixes a bug reported by @Peter-Metz in [discourse](http://discourse.pslmodels.org/t/using-non-current-law-baseline-policy-in-tax-brain-api/44/3). Thanks for the bug report!

cc @andersonfrailey 