### PR TITLE
Produce reports using pandoc

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
     - cairo
     - pango
     - phantomjs
-    - weasyprint
     - tabulate
     - selenium
     - pypandoc

--- a/environment.yml
+++ b/environment.yml
@@ -24,6 +24,3 @@ dependencies:
 - firefox
 - pip:
   - cs-kit
-  - WeasyPrint
-  - phantomjs
-  

--- a/example.py
+++ b/example.py
@@ -39,5 +39,5 @@ outdir = "larsonreform"
 name = "The Social Security 2100 Act: Rep. John Larson"
 author = "Anderson Frailey"
 report(
-    tb_dynamic, name=name, author=author
+    tb_dynamic, name=name, author=author, outdir=outdir
 )

--- a/example.py
+++ b/example.py
@@ -1,5 +1,4 @@
-
-from taxbrain import TaxBrain
+from taxbrain import TaxBrain, report
 
 
 reform_url = "https://raw.githubusercontent.com/PSLmodels/Tax-Calculator/master/taxcalc/reforms/Larson2019.json"
@@ -34,3 +33,11 @@ dist = tb_dynamic.distribution_table(2019, "weighted_deciles",
                                      "expanded_income", "reform")
 print("\nDistribution Table for 2019")
 print(dist)
+
+# produce a pdf report summarizing the effects of the reform
+outdir = "larsonreform"
+name = "The Social Security 2100 Act: Rep. John Larson"
+author = "Anderson Frailey"
+report(
+    tb_dynamic, name=name, author=author
+)

--- a/taxbrain/report_files/report_template.md
+++ b/taxbrain/report_files/report_template.md
@@ -1,53 +1,44 @@
-~article id="cover"
-
-# {{ title}} {: #title}
-
-### {{ author }} {: #author}
-{{ date }}
-{: #date}
-
-~/article
-
-~article id="contents"
+% {{ title}}
+% {{ author }}
+% {{ date }}
 
 ## Table of Contents
 
-### [Introduction](#introduction)
-* [Analysis Summary](#summary)
-* [Notable Changes](#notable)
-### [Aggregate Changes](#aggregate)
-### [Distributional Analysis](#distributional)
-### [Summary of Policy Changes](#policychange)
-### [Baseline Policy](#baseline)
-### [Assumptions](#assumptions)
-* [Behavioral Assumptions](#behavior)
-* [Consumption Assumptions](#consumption)
-* [Growth Assumptions](#growth)
+### [Introduction](#Introduction)
+* [Analysis Summary](#Summary)
+* [Notable Changes](#Notable-Changes)
+
+### [Aggregate Changes](#Aggregate-Changes)
+### [Distributional Analysis](#Distributional-Analysis)
+### [Summary of Policy Changes](#Summary-of-Policy-Changes)
+### [Baseline Policy](#Policy-Baseline)
+### [Assumptions](#Assumptions)
+* [Behavioral Assumptions](#Behavioral-Assumptions)
+* [Consumption Assumptions](#Consumption-Assumptions)
+* [Growth Assumptions](#Growth-Assumptions)
+
 ### [Citations](#citations)
 
-~/article
+\vfill
+![]({{ taxbrain }}){.center}
 
-~article id="introduction"
+\pagebreak
 
 ## Introduction
 
 This report summarizes the fiscal impact of {{ introduction }}. The baseline for this analysis is current law as of {{ baseline_intro }}.
 
-## Summary {: #summary}
+## Summary
 
 Over the budget window  ({{ start_year }} to {{ end_year }}), this policy is expected to {{ rev_direction }} aggregate tax liability by ${{ rev_change }}. Those with expanded income {{ largest_change_group}} are expected to see the largest change in tax liability. On average, this group can expect to see their tax liability {{ largest_change_str }}.
 
 {{ ati_change_graph }}
 
-## Notable Changes {: #notable}
+## Notable Changes
 
 {% for change in notable_changes %}
 * {{ change }}
 {% endfor %}
-
-~/article
-
-~article id="aggregate"
 
 ## Aggregate Changes
 
@@ -59,23 +50,15 @@ Over the budget window  ({{ start_year }} to {{ end_year }}), this policy is exp
 
 {{ agg_tax_type }}
 
-<img src="{{ agg_graph }}">
-
-~/article
-
-~article id="distributional"
+![Change in Aggregate Tax Liability]({{ agg_graph }}){ width=75% }
 
 ## Distributional Analysis
 
 {{ differences_table }}
 
-<img src="{{ distribution_graph }}">
+![Percentage Change in After Tax Income]({{ distribution_graph }}){ width=80% }
 
-~/article
-
-~article id="policychange"
-
-## Summary of Policy Changes {: #policysummary}
+## Summary of Policy Changes
 
 {% for year, summary in reform_summary.items() %}
 _{{ year }}_
@@ -83,27 +66,19 @@ _{{ year }}_
 {{ summary }}
 {% endfor %}
 
-~/article
-
-~article id="baseline"
-
 ## Policy Baseline
 
 {{ policy_baseline }}
 
-~/article
-
-~article id="assumptions"
-
 ## Assumptions
 
-### Behavioral Assumptions {: #behavior}
+### Behavioral Assumptions
 
 {% for item in behavior_assumps %}
 * {{item}}
 {% endfor %}
 
-### Consumption Assumptions {: #consumption}
+### Consumption Assumptions
 
 {% for year, summary in consump_assumps.items() %}
 {{ year }}
@@ -111,17 +86,13 @@ _{{ year }}_
 {{ summary }}
 {% endfor %}
 
-### Growth Assumptions {: #growth}
+### Growth Assumptions
 
 {% for year, summary in growth_assumps.items() %}
 {{ year }}
 
 {{ summary }}
 {% endfor %}
-
-~/article
-
-~article id="citations"
 
 ## Citations
 
@@ -130,5 +101,3 @@ This analysis was conducted using the following open source economic models:
 {% for model in model_versions %}
 * {{ model.name }} release {{ model.release }}
 {% endfor %}
-
-~/article

--- a/taxbrain/report_utils.py
+++ b/taxbrain/report_utils.py
@@ -3,7 +3,6 @@ Helper Functions for creating the automated reports
 """
 import re
 import json
-import weasyprint
 import markdown
 import pypandoc
 import numpy as np

--- a/taxbrain/report_utils.py
+++ b/taxbrain/report_utils.py
@@ -39,8 +39,12 @@ notable_vars = {
     "aftertax_income": "After-tax income"
 }
 
+DIFF_TABLE_ROW_NAMES = ['<$0K', '=$0K', '$0-10K', '$10-20K', '$20-30K',
+                        '$30-40K', '$40-50K', '$50-75K', '$75-100K',
+                        '$100-200K', '$200-500K', '$500K-1M', '>$1M', 'ALL']
 
-def md_to_pdf(md_text, base_url, css_path=None):
+
+def md_to_pdf(md_text, outputfile_path):
     """
     Convert Markdown version of report to a PDF. Returns bytes that can be
     saved as a PDF
@@ -55,44 +59,13 @@ def md_to_pdf(md_text, base_url, css_path=None):
     -------
     Bytes that can be saved as a PDF and the HTML used to create the report
     """
-    # try pandoc and weasyprint
-    extention_str = "markdown.extensions.{}"
-    md_extensions = [
-        extention_str.format("tables"),
-        extention_str.format("attr_list")
-    ]
-    md = markdown.markdown(md_text, extensions=md_extensions)
-    # split the HTML into a list so that we can replace `article` tags
-    split_html = md.split("\n")
-    final_html_list = []
-    tag_pattern = '<p>~article id="[a-z]*"'
-    id_pattern = 'id="[a-z]*"'
-    for line in split_html:
-        # search and see if this line should be an article tag
-        if re.match(tag_pattern, line):
-            # if it's an article tag, pull the id portion of the line and
-            # create a proper HTML tag
-            search = re.search(id_pattern, line)
-            id_name = line[search.start(): search.end()]
-            line = f"<article {id_name}>"
-        # append the line to the list that will be used to create final HTML
-        final_html_list.append(line)
-    # join the HTML on the new line character before converting to PDF
-    joined_html = "\n".join(final_html_list)
-    # also insert proper article end tags
-    # adding page-break-before style ensures sections are on different pages
-    joined_html = joined_html.replace(
-        "<p>~/article</p>",
-        '</article>\n<p style="page-break-before: always" ></p>'
+    # convert markdown text to pdf with pandoc
+    pypandoc.convert_text(
+        md_text, 'pdf', format='md', outputfile=outputfile_path,
+        extra_args=[
+            '-V', 'geometry:margin=1in'
+        ]
     )
-    if not css_path:
-        css_path = Path(CUR_PATH, "report_files", "report_style.css")
-    css = weasyprint.CSS(filename=css_path)
-    wpdf = weasyprint.HTML(
-        string=joined_html, base_url=base_url
-    ).write_pdf(stylesheets=[css])
-
-    return wpdf, joined_html
 
 
 def convert_table(df):

--- a/taxbrain/tests/test_report.py
+++ b/taxbrain/tests/test_report.py
@@ -16,7 +16,6 @@ def test_report(tb_static):
     assert dir_path.exists()
     assert Path(dir_path, "Test-Report.md").exists()
     assert Path(dir_path, "Test-Report.pdf").exists()
-    assert Path(dir_path, "Test-Report.html").exists()
     diff_png = Path(dir_path, "difference_graph.png")
     assert diff_png.exists()
     dist_png = Path(dir_path, "dist_graph.png")

--- a/taxbrain/utils.py
+++ b/taxbrain/utils.py
@@ -96,7 +96,7 @@ def distribution_plot(tb, year, width=500, height=400):
     plot.hbar_stack(
         change_groups, y="group", height=0.8, color=GnBu5,
         source=ColumnDataSource(plot_data),
-        legend=legend_labels
+        legend_label=legend_labels
     )
     # general formatting
     plot.yaxis.axis_label = "Expanded Income Bin"


### PR DESCRIPTION
This PR slightly changes how the automated reports are generated so that we no longer need weasyprint. The code to create the report is now, in my opinion, easier to maintain and that's one less dependency we have to worry about. The content of the report hasn't changed. 

Hopefully with these changes we'll be able to get a new version of TaxBrain up on conda soon. Right now we haven't been able to because conda has been having trouble putting the package together with the weasyprint dependency.

cc @hdoupe 