### PR TITLE
Remove dask from the conda meta.yml file

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -7,7 +7,6 @@ requirements:
     - python
     - "taxcalc>=3.0.0"
     - "behresp>=0.11.0"
-    - dask
 
   run:
     - python


### PR DESCRIPTION
I think this will help resolve the issues I'm having building the new Tax-Brain package. Dask is still in the `run` section so if I'm understanding the [docs](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html#requirements-section) correctly, it'll still be installed when users install the package.