### PR TITLE
remove everything from the build requirements

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,8 +5,6 @@ package:
 requirements:
   build:
     - python
-    - "taxcalc>=3.0.0"
-    - "behresp>=0.11.0"
 
   run:
     - python


### PR DESCRIPTION
I'm going to try leaving only python in the build requirements. Again, if I'm reading the docs right, all of the packages in the `run` section will still be installed for users when they install the actual package and things should work as expected.