### PR TITLE
Update conda meta...again

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -5,6 +5,15 @@ package:
 requirements:
   build:
     - python
+    - "taxcalc>=3.0.0"
+    - "behresp>=0.11.0"
+    - dask
+    - bokeh
+    - markdown
+    - tabulate
+    - pypandoc
+    - matplotlib
+    - "numpy>=1.14"
 
   run:
     - python


### PR DESCRIPTION
My battle with conda and package builder continues. I'm adding all of the dependencies back to the `build` requirements. It worked when I made a local package. TBD if it works for the real one