### PR TITLE
Add latex install

### DIFF
--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,8 +1,4 @@
 # bash commands for installing your package
 conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "taxcalc>=2.5.0" "paramtools>=0.10.2" bokeh pypandoc
 pip install cs2tc
-<<<<<<< HEAD
 apt-get install texlive-latex-base -y
-=======
-pip install pdflatex
->>>>>>> master

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,4 +1,4 @@
 # bash commands for installing your package
 conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "taxcalc>=2.5.0" "paramtools>=0.10.2" bokeh pypandoc
 pip install cs2tc
-apt-get install texlive-latex-base -y
+apt-get install texlive - y

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,4 +1,4 @@
 # bash commands for installing your package
 conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "taxcalc>=2.5.0" "paramtools>=0.10.2" bokeh pypandoc
 pip install cs2tc
-apt-get install texlive - y
+apt-get install texlive -y

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,3 +1,4 @@
 # bash commands for installing your package
 conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "taxcalc>=2.5.0" "paramtools>=0.10.2" bokeh pypandoc
 pip install cs2tc
+apt-get install texlive-latex-base -y


### PR DESCRIPTION
This PR adds a command to install Latex to the CS server. @hdoupe I believe that this should resolve our issues with CS and the reports. I've tried testing in the Docker container you set up for me, but the tests kept getting killed for some reason. But the added command does successfully install `pdflatex` which is what the tests on compute studio are currently saying is missing.