### PR TITLE
Update CS Start Year

### DIFF
--- a/cs-config/cs_config/constants.py
+++ b/cs-config/cs_config/constants.py
@@ -1,6 +1,7 @@
 # constants used by the new compconfig
 import paramtools
 from marshmallow import fields, Schema
+from datetime import datetime
 from taxbrain import TaxBrain
 
 
@@ -132,7 +133,7 @@ class MetaParameters(paramtools.Parameters):
             "title": "Start Year",
             "description": "Year for parameters.",
             "type": "int",
-            "value": 2019,
+            "value": min(datetime.now().year, TaxBrain.LAST_BUDGET_YEAR),
             "validators": {
                 "choice": {
                     "choices": [


### PR DESCRIPTION
This PR updates the start year for the Tax-Brain compute studio app to be the minimum of the current year and the final budget year in tax-calc.

cc @hdoupe 