### PR TITLE
Update cs-config deps

### DIFF
--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,4 +1,4 @@
 # bash commands for installing your package
-conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.3.2" "taxcalc>=2.5.0" "paramtools>=0.10.2" bokeh pypandoc
+conda install -c pslmodels -c conda-forge nodejs "taxbrain>=2.4.0" "taxcalc>=3.0.0" "paramtools>=0.16.0" bokeh pypandoc
 pip install cs2tc
 apt-get install texlive -y


### PR DESCRIPTION
Hey @andersonfrailey, I noticed that Tax-Brain 2.3.2 was installed which caused the cs build error. This just bumps the dependencies for:

- taxbrain>=2.4.0
- taxcalc>=3.0.0
- paramtools>=0.16.0