### PR TITLE
Catch paramtools error

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -70,8 +70,13 @@ def validate_inputs(meta_params_dict, adjustment, errors_warnings):
     """
     pol_params = cs2tc.convert_policy_adjustment(adjustment["policy"])
     policy_params = taxcalc.Policy()
-    policy_params.adjust(pol_params, raise_errors=False, ignore_warnings=True)
-    errors_warnings["policy"]["errors"].update(policy_params.errors)
+    # TODO: After paramtools updatre remove try/except block.
+    try:
+        policy_params.adjust(pol_params, raise_errors=False, ignore_warnings=True)
+        errors_warnings["policy"]["errors"].update(policy_params.errors)
+    except paramtools.ValidationError as e:
+        errors_warnings["policy"]["errors"] = policy_params.errors
+
 
     behavior_params = BehaviorParams()
     behavior_params.adjust(adjustment["behavior"], raise_errors=False)

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -3,6 +3,7 @@ from cs_kit import CoreTestFunctions
 from cs_config import functions
 
 import copy
+import json
 
 
 OK_ADJUSTMENT = {
@@ -25,23 +26,32 @@ OK_ADJUSTMENT = {
 }
 
 
+# BAD_ADJUSTMENT = {
+#     "policy": {
+#         "STD": [
+#             {"MARS": "single", "year": 2019, "value": -10},
+#             {"MARS": "mjoint", "year": 2019, "value": 1},
+#             {"MARS": "mjoint", "year": 2022, "value": 10}
+#         ],
+#         "parameter_indexing_CPI_offset": [
+#             {"year": 2019, "value": -0.001}
+#         ],
+#         "ACTC_c": [{"year": 2019, "value": 2000.0}],
+#     },
+#     "behavior": {
+#         "sub": [
+#             {"value": -0.1}
+#         ]
+#     }
+# }
+
 BAD_ADJUSTMENT = {
+    "behavior": {},
     "policy": {
-        "STD": [
-            {"MARS": "single", "year": 2019, "value": -10},
-            {"MARS": "mjoint", "year": 2019, "value": 1},
-            {"MARS": "mjoint", "year": 2022, "value": 10}
-        ],
-        "parameter_indexing_CPI_offset": [
-            {"year": 2019, "value": -0.001}
-        ],
-        "ACTC_c": [{"year": 2019, "value": 2000.0}],
+        "II_brk7_checkbox": [{"value": True}],
+        "II_brk7": [{"value": 445400, "MARS": "single", "year": 2020}],
+        "II_brk6": [{"value": 316700, "MARS": "single", "year": 2020}],
     },
-    "behavior": {
-        "sub": [
-            {"value": -0.1}
-        ]
-    }
 }
 
 

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -3,7 +3,6 @@ from cs_kit import CoreTestFunctions
 from cs_config import functions
 
 import copy
-import json
 
 
 OK_ADJUSTMENT = {

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -26,33 +26,25 @@ OK_ADJUSTMENT = {
 }
 
 
-# BAD_ADJUSTMENT = {
-#     "policy": {
-#         "STD": [
-#             {"MARS": "single", "year": 2019, "value": -10},
-#             {"MARS": "mjoint", "year": 2019, "value": 1},
-#             {"MARS": "mjoint", "year": 2022, "value": 10}
-#         ],
-#         "parameter_indexing_CPI_offset": [
-#             {"year": 2019, "value": -0.001}
-#         ],
-#         "ACTC_c": [{"year": 2019, "value": 2000.0}],
-#     },
-#     "behavior": {
-#         "sub": [
-#             {"value": -0.1}
-#         ]
-#     }
-# }
-
 BAD_ADJUSTMENT = {
-    "behavior": {},
     "policy": {
-        "II_brk7_checkbox": [{"value": True}],
-        "II_brk7": [{"value": 445400, "MARS": "single", "year": 2020}],
-        "II_brk6": [{"value": 316700, "MARS": "single", "year": 2020}],
+        "STD": [
+            {"MARS": "single", "year": 2019, "value": -10},
+            {"MARS": "mjoint", "year": 2019, "value": 1},
+            {"MARS": "mjoint", "year": 2022, "value": 10}
+        ],
+        "parameter_indexing_CPI_offset": [
+            {"year": 2019, "value": -0.001}
+        ],
+        "ACTC_c": [{"year": 2019, "value": 2000.0}],
     },
+    "behavior": {
+        "sub": [
+            {"value": -0.1}
+        ]
+    }
 }
+
 
 
 CHECKBOX_ADJUSTMENT = {
@@ -84,3 +76,15 @@ class TestFunctions2(CoreTestFunctions):
     run_model = functions.run_model
     ok_adjustment = CHECKBOX_ADJUSTMENT
     bad_adjustment = BAD_ADJUSTMENT
+
+
+def test_doesnt_cause_error():
+    adj = {
+        "behavior": {},
+        "policy": {
+            "II_brk7_checkbox": [{"value": True}],
+            "II_brk7": [{"value": 445400, "MARS": "single", "year": 2020}],
+            "II_brk6": [{"value": 316700, "MARS": "single", "year": 2020}],
+        },
+    }
+    assert functions.validate_inputs({}, adj, {"policy": {"errors": {}}, "behavior": {"errors": {}}})


### PR DESCRIPTION
ParamTools is throwing an error when it shouldn't (i.e. `raise_errors=False`). This PR updates `validate_inputs` to catch the exception and save the errors while I fix the problem in ParamTools.

cc @andersonfrailey 

Related #145 