### PR TITLE
Skip report creation for non-reform CS runs

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -149,20 +149,21 @@ def run_model(meta_params_dict, adjustment):
         for key, value in result.items():
             all_to_process[key] += value
     results, downloadable = postprocess(all_to_process)
-    # create report output
-    report_outputs = report(tb, clean=True)
-    for name, data in report_outputs.items():
-        if name.endswith(".md"):
-            media_type = "Markdown"
-        elif name.endswith(".pdf"):
-            media_type = "PDF"
-        downloadable.append(
-            {
-                "media_type": media_type,
-                "title": name,
-                "data": data
-            }
-        )
+    # create report output if it is not a run with no reforme
+    if tb.params["policy"].keys():
+        report_outputs = report(tb, clean=True)
+        for name, data in report_outputs.items():
+            if name.endswith(".md"):
+                media_type = "Markdown"
+            elif name.endswith(".pdf"):
+                media_type = "PDF"
+            downloadable.append(
+                {
+                    "media_type": media_type,
+                    "title": name,
+                    "data": data
+                }
+            )
     agg_output, table_output = create_layout(results, start_year, end_year)
 
     comp_outputs = {

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -44,6 +44,11 @@ BAD_ADJUSTMENT = {
     }
 }
 
+EMPTY_ADJUSTMENT = {
+    "policy": {},
+    "behavior": {}
+}
+
 
 CHECKBOX_ADJUSTMENT = {
     "policy": {
@@ -73,4 +78,13 @@ class TestFunctions2(CoreTestFunctions):
     validate_inputs = functions.validate_inputs
     run_model = functions.run_model
     ok_adjustment = CHECKBOX_ADJUSTMENT
+    bad_adjustment = BAD_ADJUSTMENT
+
+
+class TestFunctions3(CoreTestFunctions):
+    get_version = functions.get_version
+    get_inputs = functions.get_inputs
+    validate_inputs = functions.validate_inputs
+    run_model = functions.run_model
+    ok_adjustment = EMPTY_ADJUSTMENT
     bad_adjustment = BAD_ADJUSTMENT


### PR DESCRIPTION
This report tells the Tax-Brain CS app to skip creating reports when no reform is implemented. This would previously throw and error when trying to create a reform. Now, we just don't include a PDF report when there are no parameters changed. In the future we should come up with a new policy report to produce when there are no changes.

cc @hdoupe 