### PR TITLE
Add volcano plot

### DIFF
--- a/taxbrain/tests/test_utils.py
+++ b/taxbrain/tests/test_utils.py
@@ -1,0 +1,19 @@
+import taxbrain
+import pytest
+
+
+def test_distribution_plot(tb_static):
+    fig = taxbrain.distribution_plot(tb_static, 2019)
+
+
+def test_differences_plot(tb_static):
+    fig = taxbrain.differences_plot(tb_static, "combined")
+    with pytest.raises(AssertionError):
+        taxbrain.differences_plot(tb_static, "wages")
+
+
+def test_volcano_plot(tb_static):
+    fig = taxbrain.volcano_plot(tb_static, 2019)
+    with pytest.raises(ValueError):
+        taxbrain.volcano_plot(tb_static, 2019, min_y=-10000)
+    fig = taxbrain.volcano_plot(tb_static, 2019, min_y=-1000, log_scale=False)

--- a/taxbrain/tests/test_utils.py
+++ b/taxbrain/tests/test_utils.py
@@ -17,3 +17,8 @@ def test_volcano_plot(tb_static):
     with pytest.raises(ValueError):
         taxbrain.volcano_plot(tb_static, 2019, min_y=-10000)
     fig = taxbrain.volcano_plot(tb_static, 2019, min_y=-1000, log_scale=False)
+    # testing using RGB tuples for the colors
+    fig = taxbrain.volcano_plot(
+        tb_static, 2019,
+        increase_color=(0.1, 0.2, 0.5), decrease_color=(0.2, 0.2, 0.5)
+    )

--- a/taxbrain/typing.py
+++ b/taxbrain/typing.py
@@ -1,7 +1,8 @@
-from typing import Union, Mapping, Any, List
+from typing import Union, Mapping, Any, List, Tuple
 
 import paramtools
 
 
 TaxcalcReform = Union[str, Mapping[int, Any]]
 ParamToolsAdjustment = Union[str, List[paramtools.ValueObject]]
+PlotColors = Union[str, Tuple[float, float, float]]

--- a/taxbrain/utils.py
+++ b/taxbrain/utils.py
@@ -7,10 +7,10 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 import matplotlib.ticker as ticker
 from collections import defaultdict
-from typing import Union
+from typing import Union, Tuple
 
 import taxcalc as tc
-from .typing import ParamToolsAdjustment, TaxcalcReform
+from .typing import ParamToolsAdjustment, TaxcalcReform, PlotColors
 
 
 def weighted_sum(df, var, wt="s006"):
@@ -198,11 +198,23 @@ def is_paramtools_format(reform: Union[TaxcalcReform, ParamToolsAdjustment]):
             return True
 
 
-def volcano_plot(tb, year, y_var="expanded_income", x_var="combined",
-                 min_y=0, max_y=9e99, log_scale=True,
-                 increase_color="#F15FE4", decrease_color="#41D6C2",
-                 dotsize=.75, figsize=(6, 4), dpi=100,
-                 xlabel="Change in Tax Liability", ylabel="Expanded Income"):
+def volcano_plot(
+    tb,
+    year: int,
+    y_var: str = "expanded_income",
+    x_var: str = "combined",
+    min_y: Union[int, float] = 0.01,
+    max_y: Union[int, float] = 9e99,
+    log_scale: bool = True,
+    increase_color: PlotColors = "#F15FE4",
+    decrease_color: PlotColors = "#41D6C2",
+    dotsize: Union[int, float] = .75, 
+    alpha: float = 0.5,
+    figsize: Tuple[Union[int, float], Union[int, float]] = (6, 4),
+    dpi: Union[int, float] = 100,
+    xlabel: str = "Change in Tax Liability",
+    ylabel: str = "Expanded Income"
+):
     """
     Create a volacnoe plot to show change in tax tax liability
 
@@ -211,7 +223,7 @@ def volcano_plot(tb, year, y_var="expanded_income", x_var="combined",
     tb: TaxBrain instance
     year: year for the plot
     min_y: minimum amount for the y variable to be included in the plot
-    max_Y: maximum amount for the y variable to be included in the plot
+    max_y: maximum amount for the y variable to be included in the plot
     y_var: variable on the y axis
     x_var: variable on the x axis
     log_scale: boolean value to indicate if the y-axis should use a log scale.
@@ -219,6 +231,7 @@ def volcano_plot(tb, year, y_var="expanded_income", x_var="combined",
     increase_color: color to use for dots when x increases
     decrease_color: color to use for dots when x decrease
     dotsize: size of the dots in the scatter plot
+    alpha: attribute for transparency of the dots
     figsize: tuple containing the figure size of the plot: (width, height)
     dpi: dots per inch in the figure. A higher value increases image quality
     xlabel: label on the x axis
@@ -244,14 +257,14 @@ def volcano_plot(tb, year, y_var="expanded_income", x_var="combined",
     mask = np.logical_and(_y >= min_y, _y <= max_y)
     y = _y[mask]
     x_change = _x_change[mask]
-    colors = np.where(x_change >= 0, increase_color, decrease_color)
+    colors = [increase_color if x >= 0 else decrease_color for x in x_change]
     xformatter = ticker.FuncFormatter(axis_formatter)
     yformatter = ticker.FuncFormatter(axis_formatter)
     if log_scale:
         yformatter = ticker.FuncFormatter(log_axis)
         y = np.log(y)
     fig, ax = plt.subplots(figsize=figsize)
-    ax.scatter(x_change, y, c=colors, s=dotsize)
+    ax.scatter(x_change, y, c=colors, s=dotsize, alpha=alpha)
     ax.axvline(0, color='black', alpha=0.5)
     ax.grid(True, linestyle="--")
     ax.xaxis.set_major_formatter(xformatter)

--- a/taxbrain/utils.py
+++ b/taxbrain/utils.py
@@ -5,6 +5,7 @@ import pandas as pd
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+import matplotlib.ticker as ticker
 from collections import defaultdict
 from typing import Union
 
@@ -195,3 +196,68 @@ def is_paramtools_format(reform: Union[TaxcalcReform, ParamToolsAdjustment]):
             # Not doing a specific check to see if the value is a list
             # since it could be a list or just a scalar value.
             return True
+
+
+def volcano_plot(tb, year, y_var="expanded_income", x_var="combined",
+                 min_y=0, max_y=9e99, log_scale=True,
+                 increase_color="#F15FE4", decrease_color="#41D6C2",
+                 dotsize=.75, figsize=(6, 4), dpi=100,
+                 xlabel="Change in Tax Liability", ylabel="Expanded Income"):
+    """
+    Create a volacnoe plot to show change in tax tax liability
+
+    Parameters
+    ----------
+    tb: TaxBrain instance
+    year: year for the plot
+    min_y: minimum amount for the y variable to be included in the plot
+    max_Y: maximum amount for the y variable to be included in the plot
+    y_var: variable on the y axis
+    x_var: variable on the x axis
+    log_scale: boolean value to indicate if the y-axis should use a log scale.
+               If this is true, min_inc must be >= 0
+    increase_color: color to use for dots when x increases
+    decrease_color: color to use for dots when x decrease
+    dotsize: size of the dots in the scatter plot
+    figsize: tuple containing the figure size of the plot: (width, height)
+    dpi: dots per inch in the figure. A higher value increases image quality
+    xlabel: label on the x axis
+    ylabel: label on the y axis
+    """
+    def log_axis(x, pos):
+        """
+        Converts y-axis log values
+        """
+        return f"${np.exp(x):,.0f}"
+
+    def axis_formatter(x, pos):
+        if x >= 0:
+            return f"${x:,.0f}"
+        else:
+            return f"-${abs(x):,.0f}"
+
+    if log_scale and min_y < 0:
+        msg = "`min_y` must be >= 0 when `log_scale` is true"
+        raise ValueError(msg)
+    _y = tb.base_data[year][y_var]
+    _x_change = tb.reform_data[year][x_var] - tb.base_data[year][x_var]
+    mask = np.logical_and(_y >= min_y, _y <= max_y)
+    y = _y[mask]
+    x_change = _x_change[mask]
+    colors = np.where(x_change >= 0, increase_color, decrease_color)
+    xformatter = ticker.FuncFormatter(axis_formatter)
+    yformatter = ticker.FuncFormatter(axis_formatter)
+    if log_scale:
+        yformatter = ticker.FuncFormatter(log_axis)
+        y = np.log(y)
+    fig, ax = plt.subplots(figsize=figsize)
+    ax.scatter(x_change, y, c=colors, s=dotsize)
+    ax.axvline(0, color='black', alpha=0.5)
+    ax.grid(True, linestyle="--")
+    ax.xaxis.set_major_formatter(xformatter)
+    ax.xaxis.set_tick_params(rotation=25)
+    ax.yaxis.set_major_formatter(yformatter)
+    ax.set_xlabel(xlabel, fontweight="bold")
+    ax.set_ylabel(ylabel, fontweight="bold")
+
+    return fig


### PR DESCRIPTION
This PR adds a function to create a volcano plot similar to what can be found in this NYTimes [article](https://www.nytimes.com/interactive/2017/12/17/upshot/tax-calculator.html). Here is an example:
![image](https://user-images.githubusercontent.com/20684675/104401413-c013d280-5519-11eb-8931-16137ab3f2f0.png)

It also adds some tests for all of the plotting functions. 