### PR TITLE
cs2tc already installed through the `environment.yml` file

### DIFF
--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,4 +1,3 @@
 # bash commands for installing your package
 conda install -c pslmodels -c conda-forge "taxbrain>=2.4.0"
-pip install cs2tc
 apt-get install texlive -y


### PR DESCRIPTION
I'm having some issues with the Tax-Brain release. It seems like `cs_kit` is getting uninstalled somehow when running `cs-config/install.sh`. I'm going to drop this install statement and see if that resolves the issue.