### PR TITLE
Fix cs install errors

### DIFF
--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,3 +1,3 @@
 # bash commands for installing your package
 conda install -c pslmodels -c conda-forge "taxbrain>=2.4.0"
-apt-get install texlive -y
+#apt-get install texlive -y

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,7 +1,6 @@
 # bash commands for installing your package
 git fetch origin tags 2.5.0 && \
   git checkout -b v2.5.0 2.5.0 && \
-  git branch --show-current && \
   pip install --no-deps -e .
 
 apt-get install texlive -y

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,3 +1,6 @@
 # bash commands for installing your package
-conda install --no-deps -c pslmodels "taxbrain>=2.4.0"
-#apt-get install texlive -y
+git checkout -b v2.5.0 2.5.0 && \
+  git branch --show-current && \
+  pip install --no-deps -e .
+
+apt-get install texlive -y

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,5 +1,6 @@
 # bash commands for installing your package
-git checkout -b v2.5.0 2.5.0 && \
+git fetch origin tags 2.5.0 && \
+  git checkout -b v2.5.0 2.5.0 && \
   git branch --show-current && \
   pip install --no-deps -e .
 

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,3 +1,3 @@
 # bash commands for installing your package
-conda install -c pslmodels -c conda-forge "taxbrain>=2.4.0"
+conda install --no-deps -c pslmodels "taxbrain>=2.4.0"
 #apt-get install texlive -y

--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,5 +1,5 @@
 # bash commands for installing your package
-git fetch origin tags 2.5.0 && \
+git fetch origin tag 2.5.0 && \
   git checkout -b v2.5.0 2.5.0 && \
   pip install --no-deps -e .
 

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,5 @@
 name: taxbrain-dev
 channels:
-- pslmodels
 - conda-forge
 dependencies:
 - python>=3.6.5

--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,6 @@
 name: taxbrain-dev
 channels:
-- PSLmodels
+- pslmodels
 - conda-forge
 dependencies:
 - python>=3.6.5


### PR DESCRIPTION
This removes the conda install and checks out the `2.5.0` tag when installing Tax-Brain on CS. In addition to 2.5.0 not being up on conda yet, the conda install in `install.sh` was uninstalling `cs-kit` somehow. This is a work around to get a new version of TB live on CS until I have more time to dig into this.