### PR TITLE
Update required version of pandas

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ dependencies:
 - python>=3.6.5
 - taxcalc>=3.0.0
 - behresp>=0.11.0
-- pandas>=0.23
+- pandas>=1.2.3
 - numpy>=1.14
 - paramtools>=0.10.1
 - pytest


### PR DESCRIPTION
I ran into this test failure when deploying a new version of Tax-Brain to Compute Studio:

https://github.com/compute-tooling/compute-studio-publish/pull/124/checks?check_run_id=2196720004#step:9:303

I ran into a similar error when working with @MaxGhenis on publishing a CS app the other day and upgrading pandas resolved the problem.

I'll wait on @andersonfrailey to review before merging this since it affects the main repo.