### PR TITLE
Alternative parallelization in TaxBrain.run()

### DIFF
--- a/taxbrain/tests/test_brain.py
+++ b/taxbrain/tests/test_brain.py
@@ -77,6 +77,7 @@ def test_differences_table(tb_dynamic):
 
 
 def test_distribution_table(tb_static):
+    tb_static.run()
     table = tb_static.distribution_table(2019, "weighted_deciles",
                                          "expanded_income_baseline", "reform")
     assert isinstance(table, pd.DataFrame)


### PR DESCRIPTION
This PR proposes a different approach to parallelizing processes in the `TaxBrain.run()` method.  In this approach, up to 2 x number of years in budget window are done simultaneously, in contrast to the 2 at a time done currently.  

The method does add a private method and take a few more lines of code.  

In testing, the increase in time was about 25% for a 10 year budget window.  From a  couple different runs (where "serial run time" is the current method and "parallel run time" is the proposed approach:
```
In [6]: tb_static.run(client=client,num_workers=8)
Serial run time =  28.106011152267456
Parallel run time =  21.213470935821533
```

and 

```
In [6]: tb_static.run(client=client,num_workers=8)
Serial run time =  31.898165941238403
Parallel run time =  22.767035961151123
```

@andersonfrailey let me know what you think of moving from `_static_run` to something like `_static_run_parallel`

@hdoupe Is Tax-Brain parallelized on C/S?  Any advantages or draw backs on that platform from the method proposed here?