### PR TITLE
Add when validator for year parameter

### DIFF
--- a/cs-config/cs_config/constants.py
+++ b/cs-config/cs_config/constants.py
@@ -135,13 +135,13 @@ class MetaParameters(paramtools.Parameters):
             "type": "int",
             "value": min(datetime.now().year, TaxBrain.LAST_BUDGET_YEAR),
             "validators": {
-                "choice": {
-                    "choices": [
-                        yr for yr in range(TaxBrain.FIRST_BUDGET_YEAR,
-                                           TaxBrain.LAST_BUDGET_YEAR + 1)
-                    ]
+                "when": {
+                    "param": "data_source",
+                    "is": "CPS",
+                    "then": {"range": {"min": 2014, "max": TaxBrain.LAST_BUDGET_YEAR}},
+                    "otherwise": {"range": {"min": 2013, "max": TaxBrain.LAST_BUDGET_YEAR}},
                 }
-            }
+            },
         },
         "data_source": {
             "title": "Data Source",
@@ -158,3 +158,24 @@ class MetaParameters(paramtools.Parameters):
             "validators": {"choice": {"choices": [True, False]}}
         }
     }
+
+    def dump(self, *args, **kwargs):
+        """
+        This method extends the default ParamTools dump method by swapping the
+        when validator for a choice validator. This is required because C/S does
+        not yet implement the when validator.
+        """
+        data = super().dump(*args, **kwargs)
+        if self.data_source == "CPS":
+            data["year"]["validators"] = {
+                "choice": {
+                    "choices": list(range(2014, TaxBrain.LAST_BUDGET_YEAR))
+                }
+            }
+        else:
+            data["year"]["validators"] = {
+                "choice": {
+                    "choices": list(range(2013, TaxBrain.LAST_BUDGET_YEAR))
+                }
+            }
+        return data

--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -68,6 +68,10 @@ def validate_inputs(meta_params_dict, adjustment, errors_warnings):
     """
     Function to validate COMP inputs
     """
+    meta_params = MetaParameters()
+    meta_params.adjust(meta_params_dict, raise_errors=False)
+    errors_warnings["policy"]["errors"].update(meta_params.errors)
+
     pol_params = cs2tc.convert_policy_adjustment(adjustment["policy"])
     policy_params = taxcalc.Policy()
     policy_params.adjust(pol_params, raise_errors=False, ignore_warnings=True)

--- a/cs-config/cs_config/tests/test_functions.py
+++ b/cs-config/cs_config/tests/test_functions.py
@@ -7,18 +7,12 @@ OK_ADJUSTMENT = {
         "STD": [
             {"MARS": "single", "year": 2019, "value": 0},
             {"MARS": "mjoint", "year": 2019, "value": 1},
-            {"MARS": "mjoint", "year": 2022, "value": 10}
+            {"MARS": "mjoint", "year": 2022, "value": 10},
         ],
-        "parameter_indexing_CPI_offset": [
-            {"year": 2019, "value": -0.001}
-        ],
+        "parameter_indexing_CPI_offset": [{"year": 2019, "value": -0.001}],
         "EITC_c": [{"EIC": "0kids", "year": 2019, "value": 1000.0}],
     },
-    "behavior": {
-        "inc": [
-            {"value": -0.1}
-        ]
-    }
+    "behavior": {"inc": [{"value": -0.1}]},
 }
 
 
@@ -27,24 +21,15 @@ BAD_ADJUSTMENT = {
         "STD": [
             {"MARS": "single", "year": 2019, "value": -10},
             {"MARS": "mjoint", "year": 2019, "value": 1},
-            {"MARS": "mjoint", "year": 2022, "value": 10}
+            {"MARS": "mjoint", "year": 2022, "value": 10},
         ],
-        "parameter_indexing_CPI_offset": [
-            {"year": 2019, "value": -0.001}
-        ],
+        "parameter_indexing_CPI_offset": [{"year": 2019, "value": -0.001}],
         "ACTC_c": [{"year": 2019, "value": 2000.0}],
     },
-    "behavior": {
-        "sub": [
-            {"value": -0.1}
-        ]
-    }
+    "behavior": {"sub": [{"value": -0.1}]},
 }
 
-EMPTY_ADJUSTMENT = {
-    "policy": {},
-    "behavior": {}
-}
+EMPTY_ADJUSTMENT = {"policy": {}, "behavior": {}}
 
 
 CHECKBOX_ADJUSTMENT = {
@@ -52,12 +37,31 @@ CHECKBOX_ADJUSTMENT = {
         "STD": [
             {"MARS": "single", "year": 2019, "value": 10},
             {"MARS": "mjoint", "year": 2019, "value": 1},
-            {"MARS": "mjoint", "year": 2022, "value": 10}
+            {"MARS": "mjoint", "year": 2022, "value": 10},
         ],
-        "STD_checkbox": [{"value": False}]
+        "STD_checkbox": [{"value": False}],
     },
-    "behavior": {}
+    "behavior": {},
 }
+
+
+def test_start_year_with_data_source():
+    """
+    Test interaction between PUF and CPS data sources and the start year.
+    """
+    data = functions.get_inputs({"data_source": "PUF"})
+    assert data["meta_parameters"]["year"]["validators"]["choice"]["choices"][0] == 2013
+    data = functions.get_inputs({"data_source": "CPS"})
+    assert data["meta_parameters"]["year"]["validators"]["choice"]["choices"][0] == 2014
+
+    ew = {
+        "policy": {"errors": {}, "warnings": {}},
+        "behavior": {"errors": {}, "warnings": {}},
+    }
+    res = functions.validate_inputs(
+        {"data_source": "CPS", "year": 2013}, {"policy": {}, "behavior": {}}, ew
+    )
+    assert res["errors_warnings"]["policy"]["errors"].get("year")
 
 
 class TestFunctions1(CoreTestFunctions):

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - behresp>=0.11.0
 - pandas>=0.23
 - numpy>=1.14
-- paramtools>=0.10.1
+- paramtools>=0.18.1
 - pytest
 - dask
 - bokeh


### PR DESCRIPTION
- Adds the `when` validator that @jdebacker set up in https://github.com/PSLmodels/Cost-of-Capital-Calculator/pull/344.
- Extends the `dump` method for meta parameters to use the choice validator so that C/S will still show the dropdown for the `year` meta parameter even though it is actually using the `when` validator. This is necessary until C/S adds support for the `when` validator in the GUI.

Resolves #176 
