### PR TITLE
Use default version installed via git on CS

### DIFF
--- a/cs-config/install.sh
+++ b/cs-config/install.sh
@@ -1,6 +1,5 @@
 # bash commands for installing your package
-git fetch origin tag 2.5.0 && \
-  git checkout -b v2.5.0 2.5.0 && \
-  pip install --no-deps -e .
+
+pip install --no-deps -e .
 
 apt-get install texlive-plain-generic texlive -y


### PR DESCRIPTION
This removes a command to checkout the 2.5.0 tag when building the Tax-Brain app on Compute Studio. This means that the version of Tax-Brain can be set by either:
- installing from conda in `install.sh`
- Or directly in the CS [app settings:](https://compute.studio/PSLmodels/Tax-Brain/settings/environment/)
  ![image](https://user-images.githubusercontent.com/9206065/113513282-f8ceb100-9536-11eb-94b3-726b35466867.png)

For now, we'll just use the `master` branch which is Tax-Brian 2.5.0 plus some changes for Compute Studio added in the `cs-config` package.