### PR TITLE
Add stacked reform

### DIFF
--- a/taxbrain/report.py
+++ b/taxbrain/report.py
@@ -125,6 +125,13 @@ def report(tb, name=None, change_threshold=0.05, description=None,
         "author": author,
         "taxbrain": str(Path(CUR_PATH, "report_files", "taxbrain.png"))
     }
+    if tb.stacked:
+        stacked_table = tb.stacked_table * 1e-9
+        stacked_table = format_table(
+            stacked_table, [], list(stacked_table.columns)
+        )
+        stacked_table = convert_table(stacked_table)
+        text_args["stacked_table"] = stacked_table
     if verbose:
         print("Writing Introduction")
     # find policy areas used in the reform

--- a/taxbrain/report_files/report_template.md
+++ b/taxbrain/report_files/report_template.md
@@ -59,6 +59,12 @@ Over the budget window  ({{ start_year }} to {{ end_year }}), this policy is exp
 
 {{ differences_table }}
 
+{% if stacked_table %}
+**Table 4: Stacked Revenue Estimates (Billions)**
+
+{{ stacked_table }}
+{% endif %}
+
 ![Percentage Change in After Tax Income]({{ distribution_graph }})
 \ 
 

--- a/taxbrain/taxbrain.py
+++ b/taxbrain/taxbrain.py
@@ -1,4 +1,3 @@
-import enum
 import taxcalc as tc
 import pandas as pd
 import numpy as np

--- a/taxbrain/tests/test_brain.py
+++ b/taxbrain/tests/test_brain.py
@@ -37,6 +37,23 @@ def test_dynamic_run(tb_dynamic):
     tb_dynamic.run()
 
 
+def test_stacked_run():
+    # reforms to use
+    payroll_json = """{"SS_Earnings_thd": {"2021": 400000}}"""
+    CG_rate_json = """{
+        "CG_brk3": {"2021": [1000000, 1000000, 1000000, 1000000, 1000000]},
+        "CG_rt4": {"2021": 0.396}
+    }"""
+    reform_dict = {
+        "Payroll Threshold Increase": payroll_json,
+        "Capital Gains Tax Changes": CG_rate_json
+    }
+    tb = TaxBrain(2021, 2022, reform=reform_dict, stacked=True, use_cps=True)
+    tb.run()
+    # check that there is a stacked table now
+    assert isinstance(tb.stacked_table, pd.DataFrame)
+
+
 def test_weighted_totals(tb_static):
     table = tb_static.weighted_totals("combined")
     assert isinstance(table, pd.DataFrame)

--- a/taxbrain/utils.py
+++ b/taxbrain/utils.py
@@ -376,7 +376,7 @@ def lorenz_curve(
     None
     """
     plot_data = lorenz_data(tb, year, var)
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=figsize)
     ax.plot([0, 1], [0, 1], c="black", alpha=0.5)  # 45 degree line
     ax.plot(
         plot_data["Population"], plot_data["Base"], c=base_color,
@@ -391,6 +391,8 @@ def lorenz_curve(
     ax.set_ylabel(ylabel, fontweight="bold")
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
+
+    return fig
 
 
 def volcano_plot(


### PR DESCRIPTION
This PR adds a stacked reform option to TaxBrain. I still need to add some parallelization to the new `_stacked_run` method, but the general functionality is ready for review.