### PR TITLE
Fix docstring reference to microdata dictionary name

### DIFF
--- a/taxbrain/taxbrain.py
+++ b/taxbrain/taxbrain.py
@@ -60,7 +60,7 @@ class TaxBrain:
             file or a Pandas DataFrame, containing micro-data, or a
             dictionary containing a path to microdata, associated
             weights, and grow factors.  If a dict, must have keys:
-            "data", "start_year", "gfactors", "weights"
+            "data", "start_year", "growfactors", "weights"
         reform: str or dict
             Individual income tax policy reform. Can be either a string
             pointing to a JSON reform file, or the contents of a JSON file,


### PR DESCRIPTION
This PR fixes an error in a docstring in `taxbrain.py` that provided the wrong name for a key if one passes a `microdata` dictionary to the `TaxBrain` class object.