### PR TITLE
Taxcalc tmd

### DIFF
--- a/taxbrain/taxbrain.py
+++ b/taxbrain/taxbrain.py
@@ -694,13 +694,9 @@ class TaxBrain:
                 weights=tc.Records.PUF_WEIGHTS_FILENAME,
             )
         elif self.microdata == "TMD":
-            # Load TMD-specific growfactors instead of default
+            gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
             if self.params["growdiff_baseline"]:
-                # Apply any user growdiff to TMD growfactors
-                gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
                 gd_base.apply_to(gf_base)
-            else:
-                gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
 
             records = tc.Records.tmd_constructor(
                 data_path=Path(self.TMD_DATA_FILE),
@@ -754,13 +750,9 @@ class TaxBrain:
                 weights=tc.Records.PUF_WEIGHTS_FILENAME,
             )
         elif self.microdata == "TMD":
-            # Load TMD-specific growfactors instead of default
+            gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
             if self.params["growdiff_response"]:
-                # Apply any user growdiff to TMD growfactors
-                gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
                 gd_reform.apply_to(gf_reform)
-            else:
-                gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
 
             records = tc.Records.tmd_constructor(
                 data_path=Path(self.TMD_DATA_FILE),
@@ -832,13 +824,9 @@ class TaxBrain:
                 weights=tc.Records.PUF_WEIGHTS_FILENAME,
             )
         elif self.microdata == "TMD":
-            # Load TMD-specific growfactors instead of default
+            gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
             if self.params["growdiff_baseline"]:
-                # Apply any user growdiff to TMD growfactors
-                gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
                 gd_base.apply_to(gf_base)
-            else:
-                gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
 
             records = tc.Records.tmd_constructor(
                 data_path=Path(self.TMD_DATA_FILE),
@@ -895,13 +883,9 @@ class TaxBrain:
                 weights=tc.Records.PUF_WEIGHTS_FILENAME,
             )
         elif self.microdata == "TMD":
-            # Load TMD-specific growfactors instead of default
+            gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
             if self.params["growdiff_response"]:
-                # Apply any user growdiff to TMD growfactors
-                gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
                 gd_reform.apply_to(gf_reform)
-            else:
-                gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
 
             reform_records = tc.Records.tmd_constructor(
                 data_path=Path(self.TMD_DATA_FILE),

--- a/taxbrain/taxbrain.py
+++ b/taxbrain/taxbrain.py
@@ -15,7 +15,7 @@ from taxbrain.utils import weighted_sum, update_policy
 from taxbrain.corporate_incidence import distribute as dist_corp
 from typing import Union
 from paramtools import ValidationError
-
+from pathlib import Path
 
 class TaxBrain:
 
@@ -29,6 +29,11 @@ class TaxBrain:
         "Tax-Calculator": tc.__version__,
         "Behavioral-Responses": behresp.__version__,
     }
+
+    # add expected TMD filenames as constants
+    TMD_DATA_FILE = "tmd.csv.gz"
+    TMD_WEIGHTS_FILE = "tmd_weights.csv.gz"
+    TMD_GROWFACTORS_FILE = "tmd_growfactors.csv"
 
     def __init__(
         self,
@@ -689,9 +694,18 @@ class TaxBrain:
                 weights=tc.Records.PUF_WEIGHTS_FILENAME,
             )
         elif self.microdata == "TMD":
+            # Load TMD-specific growfactors instead of default
+            if self.params["growdiff_baseline"]:
+                # Apply any user growdiff to TMD growfactors
+                gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
+                gd_base.apply_to(gf_base)
+            else:
+                gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
+
             records = tc.Records.tmd_constructor(
-                "tmd.csv",
-                gfactors=gf_base,
+                data_path=Path(self.TMD_DATA_FILE),
+                weights_path=Path(self.TMD_WEIGHTS_FILE),
+                growfactors=gf_base
             )
         elif isinstance(self.microdata, dict):
             if self.microdata["growfactors"] is None:
@@ -740,9 +754,18 @@ class TaxBrain:
                 weights=tc.Records.PUF_WEIGHTS_FILENAME,
             )
         elif self.microdata == "TMD":
+            # Load TMD-specific growfactors instead of default
+            if self.params["growdiff_response"]:
+                # Apply any user growdiff to TMD growfactors
+                gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
+                gd_reform.apply_to(gf_reform)
+            else:
+                gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
+
             records = tc.Records.tmd_constructor(
-                "tmd.csv",
-                gfactors=gf_reform,
+                data_path=Path(self.TMD_DATA_FILE),
+                weights_path=Path(self.TMD_WEIGHTS_FILE),
+                growfactors=gf_reform
             )
         elif isinstance(self.microdata, dict):
             if self.microdata["growfactors"] is None:
@@ -809,9 +832,18 @@ class TaxBrain:
                 weights=tc.Records.PUF_WEIGHTS_FILENAME,
             )
         elif self.microdata == "TMD":
+            # Load TMD-specific growfactors instead of default
+            if self.params["growdiff_baseline"]:
+                # Apply any user growdiff to TMD growfactors
+                gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
+                gd_base.apply_to(gf_base)
+            else:
+                gf_base = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
+
             records = tc.Records.tmd_constructor(
-                "tmd.csv",
-                gfactors=gf_base,
+                data_path=Path(self.TMD_DATA_FILE),
+                weights_path=Path(self.TMD_WEIGHTS_FILE),
+                growfactors=gf_base
             )
         elif isinstance(self.microdata, dict):
             if self.microdata["growfactors"] is None:
@@ -863,9 +895,18 @@ class TaxBrain:
                 weights=tc.Records.PUF_WEIGHTS_FILENAME,
             )
         elif self.microdata == "TMD":
-            records = tc.Records.tmd_constructor(
-                "tmd.csv",
-                gfactors=gf_reform,
+            # Load TMD-specific growfactors instead of default
+            if self.params["growdiff_response"]:
+                # Apply any user growdiff to TMD growfactors
+                gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
+                gd_reform.apply_to(gf_reform)
+            else:
+                gf_reform = tc.GrowFactors(self.TMD_GROWFACTORS_FILE)
+
+            reform_records = tc.Records.tmd_constructor(
+                data_path=Path(self.TMD_DATA_FILE),
+                weights_path=Path(self.TMD_WEIGHTS_FILE),
+                growfactors=gf_reform
             )
         elif isinstance(self.microdata, dict):
             if self.microdata["growfactors"] is None:


### PR DESCRIPTION
The latest version of Tax-Brain (`2.7.2` at time of writing) is not compatible with Tax-Calculator `4.5.0` usage of TMD microdata. Recent releases of Tax-Calculator changed the tmd_constructor() parameters to intake grow-factors from using the keyword `gfactors` to `growfactors`. Because Tax-Brain is still using the old keyword-arguments, attempting to use TMD data via Tax-Brain will fail.

Additionally, Tax-Brain does not set up use of the TMD weights file as described in the Tax-Calculator documentation.

This change set is an attempt at fixing the issue by modifying Tax-Brain's TMD usage setup to be compatible with the Tax-Calculator API, as well as to utilize the TMD weights file.

## Reproducing the error

Using the [Static Reform](https://taxbrain.pslmodels.org/content/examples/example.html) example from the Tax-Brain documentation site, we can validate running against CPS and demonstrate the error by running againsst TMD.

This was tested using Python 3.11.

```
# requirements.txt

taxbrain
taxcalc
matplotlib
pypandoc
pandas
requests
aiohttp
```

```
# taxbrain_cps_vs_tmd.py

from taxbrain import TaxBrain

reform_url = "https://raw.githubusercontent.com/PSLmodels/Tax-Calculator/master/taxcalc/reforms/Larson2019.json"
year_start = 2019
year_end = 2020

for microdata_name in ["CPS", "TMD"]:
  print(f"Running taxbrain using {microdata_name} microdata")
  tb = TaxBrain(
        year_start,
        year_end,
        microdata=microdata_name,
        reform=reform_url,
  )

  tb.run()

  # Access the DataFrame containing data from the reform caclulator for the year 2019
  print('Calculator reform data 2029')
  print(tb.reform_data[2019])

  # Access the DataFrame containing data from the base calculator for the year 2020
  print('Calculator reform data 2020')
  print(tb.base_data[2020])

  print('-----')
```


```sh
pip install -r requirements.txt
# ...snip

# Verify taxbrain is latest, 2.7.2
pip show taxbrain
Name: taxbrain
Version: 2.7.2
Summary: Python library for advanced tax policy analysis
Home-page: https://github.com/PSLmodels/Tax-Brain
Author: Anderson Frailey
Author-email: andersonfrailey@gmail.com
License: MIT
Location: /home/ec2-user/.local/lib/python3.11/site-packages
Requires: behresp, bokeh, dask, taxcalc
Required-by: 

# Verify taxcalc is latest, 4.5.0
pip show taxcalc
Name: taxcalc
Version: 4.5.0
Summary: Tax-Calculator
Home-page: https://github.com/PSLmodels/Tax-Calculator
Author: 
Author-email: 
License: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication
Location: /home/ec2-user/.local/lib/python3.11/site-packages
Requires: bokeh, numba, numpy, pandas, paramtools
Required-by: behresp, taxbrain, tmd
```

```sh
python taxbrain_cps_vs_tmd.py
Running taxbrain using CPS microdata
Calculator reform data 2029
        c07100         taxbc  standard  refund  expanded_income  ...      combined  benefit_cost_total  c04600    payrolltax        c04470
0          0.0      0.000000   12200.0     0.0     54791.148242  ...      0.000000        54791.148242     0.0      0.000000      0.000000
1          0.0   2936.056677   24400.0     0.0     55992.476179  ...  10720.064423         1224.604684     0.0   7784.007746      0.000000
2          0.0      0.000000   15500.0     0.0     42324.108411  ...      0.000000        42324.108411     0.0      0.000000      0.000000
3          0.0    561.226937   24400.0     0.0     33803.476252  ...   5337.506016            0.000000     0.0      0.000000      0.000000
4          0.0   4788.896912   24400.0     0.0     84905.807941  ...  13059.494001            0.000000     0.0   8270.597089      0.000000
...        ...           ...       ...     ...              ...  ...           ...                 ...     ...           ...           ...
280000     0.0  12512.745301   13850.0     0.0    106525.089101  ...  12512.745301        35126.042188     0.0      0.000000      0.000000
280001     0.0      0.000000   13850.0     0.0      9572.452552  ...      0.000000         9518.211327     0.0      0.000000      0.000000
280002     0.0   2940.056393   24400.0     0.0     68097.558356  ...  10915.998577        11975.783988     0.0   7975.942184      0.000000
280003     0.0   5421.512480       0.0     0.0     60151.355731  ...  13967.215596            0.000000     0.0   8545.703116  12410.265629
280004     0.0  10231.690121       0.0     0.0     86851.994670  ...  22575.562496            0.000000     0.0  12343.872375  15347.376113

[280005 rows x 23 columns]
Calculator reform data 2020
        c07100         taxbc      standard       refund  expanded_income  ...      combined  benefit_cost_total  c04600    payrolltax        c04470
0          0.0      0.000000   7089.151966  1800.000000     56413.317272  ...  -1800.000000        56413.317272     0.0      0.000000      0.000000
1          0.0   2773.060784  24800.000000  3600.000000     56383.858389  ...   7006.738284         1266.513105     0.0   7833.677500      0.000000
2          0.0      0.000000  15505.686144  1800.000000     43759.010206  ...  -1800.000000        43759.010206     0.0      0.000000      0.000000
3          0.0    521.574282  25400.000000  3600.000000     34346.157259  ...   1774.531745            0.000000     0.0      0.000000      0.000000
4          0.0   4890.883725  24800.000000  3600.000000     87090.608958  ...   9614.255494            0.000000     0.0   8323.371769      0.000000
...        ...           ...           ...          ...              ...  ...           ...                 ...     ...           ...           ...
280000     0.0  13561.078566  14050.000000   808.618508    112575.547265  ...  12752.460058        36324.435322     0.0      0.000000      0.000000
280001     0.0      0.000000  14050.000000  1800.000000      9560.351453  ...  -1800.000000         9506.689578     0.0      0.000000      0.000000
280002     0.0   4103.062202  25400.000000  3600.000000     68735.642083  ...   8529.898873        12255.813745     0.0   8026.836671      0.000000
280003     0.0   5232.509033      0.000000  1800.000000     60534.768027  ...  12032.742281            0.000000     0.0   8600.233248  13314.155799
280004     0.0  10030.717758      0.000000  1490.257088     87406.177557  ...  20963.099295            0.000000     0.0  12422.638625  16464.322982

[280005 rows x 23 columns]
-----
Running taxbrain using TMD microdata
Traceback (most recent call last):
  File "/home/ec2-user/taxbrain-test/taxbrain_cps_vs_tmd.py", line 16, in <module>
    tb.run()
  File "/home/ec2-user/.local/lib/python3.11/site-packages/taxbrain/taxbrain.py", line 168, in run
    base_calc, reform_calc = self._make_calculators()
                             ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ec2-user/.local/lib/python3.11/site-packages/taxbrain/taxbrain.py", line 692, in _make_calculators
    records = tc.Records.tmd_constructor(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: Records.tmd_constructor() got an unexpected keyword argument 'gfactors'
```

## Commits

- TaxCalculator tmd_constructor() now uses 'growfactors' instead of 'gfactors'
- Reference TMD files for weights and growfactors