### PR TITLE
Bump python versions, prepare new release

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup TeX Live
-        uses: teatimeguest/setup-texlive-action@v3
+        uses: TeX-Live/setup-texlive-action@v3.4.2
         with:
           packages: >-
             scheme-basic

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout

--- a/.github/workflows/check_jupyterbook.yml
+++ b/.github/workflows/check_jupyterbook.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           activate-environment: taxbrain-dev
           environment-file: environment.yml
-          python-version: "3.12"
+          python-version: "3.13"
           auto-activate-base: false
 
       - name: Build # Build Jupyter Book

--- a/.github/workflows/deploy_jupyterbook.yml
+++ b/.github/workflows/deploy_jupyterbook.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           activate-environment: taxbrain-dev
           environment-file: environment.yml
-          python-version: "3.12"
+          python-version: "3.13"
           auto-activate-base: false
 
       - name: Build # Build Jupyter Book

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Tax-Brain Release History
 
+## 2025-12-19 Release 2.8.0
+
+Last Merged Pull Request: [#209](https://github.com/PSLmodels/Tax-Brain/pull/209)
+
+* Testing on Python 3.13 (drop Python 3.10): [#209](https://github.com/PSLmodels/Tax-Brain/pull/209)
+* Compatibility with Tax-Calculator > 6.0.0: [#206](https://github.com/PSLmodels/Tax-Brain/pull/205)
+
 ## 2024-09-23 Release 2.7.2
 
 Last Merged Pull Request: [#205](https://github.com/PSLmodels/Tax-Brain/pull/205)

--- a/environment.yml
+++ b/environment.yml
@@ -2,12 +2,12 @@ name: taxbrain-dev
 channels:
 - conda-forge
 dependencies:
-- python>=3.6.5
-- taxcalc>=6.0.0
-- behresp>=0.11.0
-- pandas>=0.23
-- numpy>=1.14
-- paramtools>=0.18.1
+- "python>=3.11, <3.14"
+- "taxcalc>=6.0.0"
+- "behresp>=0.11.0"
+- "numpy>=1.26"
+- "pandas>=2.2"
+- "paramtools>=0.20.0"
 - pytest
 - dask
 - bokeh

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ install_requires = ["taxcalc", "behresp", "dask", "bokeh"]
 
 with open("README.md", "r") as f:
     long_description = f.read()
-version = "2.7.2"
+version = "2.8.0"
 setuptools.setup(
     name="taxbrain",
     version=version,
@@ -19,9 +19,9 @@ setuptools.setup(
     license="MIT",
     classifiers=[
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],

--- a/taxbrain/__init__.py
+++ b/taxbrain/__init__.py
@@ -4,4 +4,6 @@ from taxbrain.cli import *
 from taxbrain.report import *
 from taxbrain.report_utils import *
 
-__version__ = "0.0.0"
+__version__ = '2.8.0'
+__min_python3_version__ = 11
+__max_python3_version__ = 13

--- a/taxbrain/__init__.py
+++ b/taxbrain/__init__.py
@@ -4,6 +4,6 @@ from taxbrain.cli import *
 from taxbrain.report import *
 from taxbrain.report_utils import *
 
-__version__ = '2.8.0'
+__version__ = "2.8.0"
 __min_python3_version__ = 11
 __max_python3_version__ = 13


### PR DESCRIPTION
This PR increases the Python versions that Tax-Brain is tested against in CI testing and also the versions for the Python package.